### PR TITLE
✨  NEW: Captions have paragraphs

### DIFF
--- a/src/mdast/tokensToMyst.ts
+++ b/src/mdast/tokensToMyst.ts
@@ -14,6 +14,7 @@ import {
 } from './utils';
 import { map } from 'unist-util-map';
 import { selectAll } from 'unist-util-select';
+import { ensureCaptionIsParagraph } from './transforms';
 
 export type Options = {
   handlers?: Record<string, Spec>;
@@ -582,13 +583,7 @@ export function tokensToMyst(tokens: Token[], options = defaultOptions): Root {
     tree = newTree as Root;
   }
 
-  // Ensure caption content is nested in a paragraph
-  visit(tree, 'caption', (node: GenericNode) => {
-    if (node.children && node.children[0].type !== 'paragraph') {
-      node.children = [{ type: 'paragraph', children: node.children }];
-    }
-  });
-
+  ensureCaptionIsParagraph(tree);
   // Replace "table node with caption" with "figure node with table and caption"
   // TODO: Clean up when we update to typescript > 4.6.2 and we have access to
   //       parent in visitor function.

--- a/src/mdast/transforms.ts
+++ b/src/mdast/transforms.ts
@@ -85,12 +85,26 @@ export function propagateTargets(tree: Root) {
   remove(tree, 'target');
 }
 
+/**
+ * Ensure caption content is nested in a paragraph.
+ *
+ * This function is idempotent!
+ */
+export function ensureCaptionIsParagraph(tree: Root) {
+  visit(tree, 'caption', (node: GenericNode) => {
+    if (node.children && node.children[0].type !== 'paragraph') {
+      node.children = [{ type: 'paragraph', children: node.children }];
+    }
+  });
+}
+
 export const transform: Plugin<[State, Options?], string, Root> =
   (state, o) => (tree: Root) => {
     const opts = {
       ...defaultOptions,
       ...o,
     };
+    ensureCaptionIsParagraph(tree);
     propagateTargets(tree);
     countState(state, tree);
     referenceState(state, tree);


### PR DESCRIPTION
Ensure that the caption transforms are always run. The caption must have a single paragraph child.