### PR TITLE
Transform for converting html nodes to mdast

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "mdast-util-to-hast": "^12.1.1",
     "myst-spec": "0.0.2",
     "rehype-format": "^4.0.1",
+    "rehype-remark": "^9.1.2",
     "rehype-stringify": "^9.0.3",
     "unified": "^10.1.1",
     "unist-builder": "^3.0.0",

--- a/src/mdast/index.ts
+++ b/src/mdast/index.ts
@@ -2,6 +2,6 @@ export * from './types';
 export * from './fromMarkdown';
 export { tokensToMyst, Options as MdastOptions } from './tokensToMyst';
 export * from './state';
-export { transform, Options as TransformOptions } from './transforms';
+export * from './transforms';
 export * from './mystToHast';
 export * from './unified';

--- a/src/mdast/mystToHast.ts
+++ b/src/mdast/mystToHast.ts
@@ -75,7 +75,7 @@ const definitionList: Handler = (h, node) => h(node, 'dl', all(h, node));
 const definitionTerm: Handler = (h, node) => h(node, 'dt', all(h, node));
 const definitionDescription: Handler = (h, node) => h(node, 'dd', all(h, node));
 
-const role: Handler = (h, node) => {
+const mystRole: Handler = (h, node) => {
   const children = [h(node, 'code', { class: 'kind' }, [u('text', `{${node.kind}}`)])];
   if (node.value) {
     children.push(h(node, 'code', {}, [u('text', node.value)]));
@@ -83,7 +83,7 @@ const role: Handler = (h, node) => {
   return h(node, 'span', { class: 'role unhandled' }, children);
 };
 
-const directive: Handler = (h, node) => {
+const mystDirective: Handler = (h, node) => {
   const directiveHeader: ElementContent[] = [
     h(node, 'code', { class: 'kind' }, [u('text', `{${node.kind}}`)]),
   ];
@@ -172,8 +172,8 @@ export const mystToHast: Plugin<[Options?], string, Root> = (opts) => (tree: Roo
       definitionList,
       definitionTerm,
       definitionDescription,
-      role,
-      directive,
+      mystRole,
+      mystDirective,
       block,
       comment,
       heading,

--- a/src/mdast/state.ts
+++ b/src/mdast/state.ts
@@ -95,7 +95,7 @@ export class State {
     const kind = kindFromNode(node);
     if (kind && kind in TargetKind) {
       let number = null;
-      if (!node.unnumbered) {
+      if (node.numbered) {
         number = this.incrementCount(node, kind as TargetKind);
         node.number = number;
       }
@@ -111,9 +111,7 @@ export class State {
 
   initializeNumberedHeaderDepths(tree: Root) {
     const headerDepths = new Set(
-      selectAll('heading', tree)
-        .filter((node) => !(node as GenericNode).unnumbered)
-        .map((node) => (node as Heading).depth),
+      selectAll('heading[numbered=true]', tree).map((node) => (node as Heading).depth),
     );
     this.targetCounts.heading = [1, 2, 3, 4, 5, 6].map((depth) =>
       headerDepths.has(depth) ? 0 : null,

--- a/src/mdast/tokensToMyst.ts
+++ b/src/mdast/tokensToMyst.ts
@@ -385,7 +385,7 @@ const defaultMdast: Record<string, Spec> = {
     },
   },
   directive: {
-    type: 'directive',
+    type: 'mystDirective',
     noCloseToken: true,
     isLeaf: true,
     getAttrs(t) {
@@ -397,7 +397,7 @@ const defaultMdast: Record<string, Spec> = {
     },
   },
   parsed_directive: {
-    type: 'directive',
+    type: 'mystDirective',
     getAttrs(t) {
       let opts = t.meta?.opts;
       if (!opts || !Object.keys(opts).length) {
@@ -419,11 +419,11 @@ const defaultMdast: Record<string, Spec> = {
     },
   },
   directive_error: {
-    type: 'directiveError',
+    type: 'mystDirectiveError',
     noCloseToken: true,
   },
   role: {
-    type: 'role',
+    type: 'mystRole',
     noCloseToken: true,
     isLeaf: true,
     getAttrs(t) {
@@ -434,7 +434,7 @@ const defaultMdast: Record<string, Spec> = {
     },
   },
   parsed_role: {
-    type: 'role',
+    type: 'mystRole',
     getAttrs(t) {
       return {
         kind: t.meta.name,
@@ -443,7 +443,7 @@ const defaultMdast: Record<string, Spec> = {
     },
   },
   role_error: {
-    type: 'roleError',
+    type: 'mystRoleError',
     noCloseToken: true,
     isLeaf: true,
     getAttrs(t) {

--- a/src/mdast/tokensToMyst.ts
+++ b/src/mdast/tokensToMyst.ts
@@ -85,7 +85,7 @@ const defaultMdast: Record<string, Spec> = {
   heading: {
     type: 'heading',
     getAttrs(token) {
-      return { depth: Number(token.tag[1]) };
+      return { depth: Number(token.tag[1]), unnumbered: token.meta?.unnumbered };
     },
   },
   hr: {
@@ -248,10 +248,17 @@ const defaultMdast: Record<string, Spec> = {
     type: 'container',
     getAttrs(token): Container {
       const name = token.meta?.name || undefined;
+      // TODO: Use unnumbered on container and eliminate this logic
+      let num;
+      if (token.meta?.numbered === false) {
+        num = false;
+      } else {
+        num = name ? true : undefined;
+      }
       return {
         kind: 'figure',
         ...normalizeLabel(name),
-        numbered: name ? true : undefined,
+        numbered: num,
         class: getClassName(token, [NUMBERED_CLASS]),
       };
     },
@@ -266,10 +273,17 @@ const defaultMdast: Record<string, Spec> = {
     type: 'table',
     getAttrs(token) {
       const name = token.meta?.name || undefined;
+      // TODO: Use unnumbered on container and eliminate this logic
+      let num;
+      if (token.meta?.numbered === false) {
+        num = false;
+      } else {
+        num = name ? true : undefined;
+      }
       return {
         kind: undefined,
         ...normalizeLabel(name),
-        numbered: name ? true : undefined,
+        numbered: num,
         class: getClassName(token, [NUMBERED_CLASS, ALIGN_CLASS]),
         align: token.meta?.align || undefined,
       };

--- a/src/mdast/transforms.ts
+++ b/src/mdast/transforms.ts
@@ -7,7 +7,7 @@ import { remove } from 'unist-util-remove';
 import { map } from 'unist-util-map';
 import { Admonition, AdmonitionKind, GenericNode } from './types';
 import { admonitionKindToTitle } from './utils';
-import { State, countState, referenceState } from './state';
+import { State, addNumbersToNodes, resolveReferences } from './state';
 
 export type Options = {
   addAdmonitionHeaders?: boolean;
@@ -106,8 +106,8 @@ export const transform: Plugin<[State, Options?], string, Root> =
     };
     ensureCaptionIsParagraph(tree);
     propagateTargets(tree);
-    countState(state, tree);
-    referenceState(state, tree);
+    addNumbersToNodes(state, tree);
+    resolveReferences(state, tree);
     liftChildren(tree, 'directive');
     liftChildren(tree, 'role');
     if (opts.addAdmonitionHeaders) addAdmonitionHeaders(tree);

--- a/src/mdast/transforms.ts
+++ b/src/mdast/transforms.ts
@@ -108,8 +108,8 @@ export const transform: Plugin<[State, Options?], string, Root> =
     propagateTargets(tree);
     addNumbersToNodes(state, tree);
     resolveReferences(state, tree);
-    liftChildren(tree, 'directive');
-    liftChildren(tree, 'role');
+    liftChildren(tree, 'mystDirective');
+    liftChildren(tree, 'mystRole');
     if (opts.addAdmonitionHeaders) addAdmonitionHeaders(tree);
     if (opts.addContainerCaptionNumbers) addContainerCaptionNumbers(tree, state);
   };

--- a/src/mdast/transforms.ts
+++ b/src/mdast/transforms.ts
@@ -1,5 +1,7 @@
 import { Root } from 'mdast';
-import { Plugin } from 'unified';
+import { unified, Plugin } from 'unified';
+import rehypeParse from 'rehype-parse';
+import rehypeRemark from 'rehype-remark';
 import { visit } from 'unist-util-visit';
 import { select, selectAll } from 'unist-util-select';
 import { findAfter } from 'unist-util-find-after';
@@ -9,12 +11,12 @@ import { Admonition, AdmonitionKind, GenericNode } from './types';
 import { admonitionKindToTitle } from './utils';
 import { State, addNumbersToNodes, resolveReferences } from './state';
 
-export type Options = {
+export type TransformOptions = {
   addAdmonitionHeaders?: boolean;
   addContainerCaptionNumbers?: boolean;
 };
 
-const defaultOptions: Record<keyof Options, true> = {
+const defaultOptions: Record<keyof TransformOptions, true> = {
   addAdmonitionHeaders: true,
   addContainerCaptionNumbers: true,
 };
@@ -98,7 +100,20 @@ export function ensureCaptionIsParagraph(tree: Root) {
   });
 }
 
-export const transform: Plugin<[State, Options?], string, Root> =
+export function convertHtmlToMdast(tree: Root) {
+  const htmlNodes = selectAll('html', tree);
+  htmlNodes.forEach((node: GenericNode) => {
+    const hast = unified().use(rehypeParse, { fragment: true }).parse(node.value);
+    const mdast = unified().use(rehypeRemark).runSync(hast);
+    node.type = 'htmlParsed';
+    node.children = mdast.children as GenericNode[];
+    visit(node, (n: GenericNode) => delete n.position);
+  });
+  liftChildren(tree, 'htmlParsed');
+  return tree;
+}
+
+export const transform: Plugin<[State, TransformOptions?], string, Root> =
   (state, o) => (tree: Root) => {
     const opts = {
       ...defaultOptions,

--- a/tests/ext.directive.spec.ts
+++ b/tests/ext.directive.spec.ts
@@ -46,7 +46,7 @@ describe('Extensions', () => {
     const parser = new MyST({ directives: { custom } });
     const myst = '```{custom}\n:name: hello\nworld\n```';
     const ast = parser.parse(myst) as GenericNode;
-    expect(ast.children?.[0].type).toEqual('directive');
+    expect(ast.children?.[0].type).toEqual('mystDirective');
     expect(ast.children?.[0].kind).toEqual('custom');
     expect(ast.children?.[0].children?.[0].type).toEqual('custom');
     expect(ast.children?.[0].children?.[0].name).toEqual('hello');

--- a/tests/state.spec.ts
+++ b/tests/state.spec.ts
@@ -1,0 +1,29 @@
+import { formatHeadingNumber, incrementHeadingCounts } from '../src/mdast/state';
+
+describe('Testing heading count', () => {
+  test.each([
+    [2, [0, 0, 0, null, 0, 0], [0, 1, 0, null, 0, 0]],
+    [1, [0, 1, 0, null, 0, 0], [1, 0, 0, null, 0, 0]],
+    [2, [1, 0, 0, null, 0, 0], [1, 1, 0, null, 0, 0]],
+    [5, [1, 1, 0, null, 0, 0], [1, 1, 0, null, 1, 0]],
+    [5, [1, 1, 0, null, 1, 0], [1, 1, 0, null, 2, 0]],
+    [2, [1, 1, 0, null, 2, 0], [1, 2, 0, null, 0, 0]],
+    [1, [1, 2, 0, null, 0, 0], [2, 0, 0, null, 0, 0]],
+  ])('incrementHeadingCounts(%s, %s)}', (depth, counts, out) => {
+    expect(incrementHeadingCounts(depth, counts)).toEqual(out);
+  });
+});
+
+describe('Testing heading numbering format', () => {
+  test.each([
+    [[0, 0, 0, null, 0, 0], ''],
+    [[0, 1, 0, null, 0, 0], '0.1'],
+    [[1, 0, 0, null, 0, 0], '1'],
+    [[1, 1, 0, null, 0, 0], '1.1'],
+    [[1, 1, 0, null, 1, 0], '1.1.0.1'],
+    [[1, 1, 0, null, 2, 0], '1.1.0.2'],
+    [[1, 2, 0, null, 0, 0], '1.2'],
+  ])('formatHeadingNumber(%s)}', (counts, out) => {
+    expect(formatHeadingNumber(counts)).toEqual(out);
+  });
+});

--- a/tests/transforms/addnumbers.spec.ts
+++ b/tests/transforms/addnumbers.spec.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { Root } from 'mdast';
+import { addNumbersToNodes, State } from '../../src';
+
+type TestFile = {
+  cases: TestCase[];
+};
+type TestCase = {
+  title: string;
+  before: Root;
+  after: Root;
+};
+
+const directory = path.join('tests', 'transforms');
+const file = 'addnumbers.yml';
+
+const testYaml = fs.readFileSync(path.join(directory, file)).toString();
+const cases = (yaml.load(testYaml) as TestFile).cases;
+
+describe('addNumbersToNodes', () => {
+  test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
+    '%s',
+    (_, { before, after }) => {
+      const transformed = addNumbersToNodes(new State(), before as Root);
+      expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
+    },
+  );
+});

--- a/tests/transforms/addnumbers.yml
+++ b/tests/transforms/addnumbers.yml
@@ -5,16 +5,19 @@ cases:
       children:
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: one
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: two
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: three
@@ -23,18 +26,21 @@ cases:
       children:
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: one
           number: '1'
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: two
           number: '2'
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: three
@@ -45,17 +51,19 @@ cases:
       children:
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: one
         - type: heading
           depth: 1
-          unnumbered: true
+          numbered: false
           children:
             - type: text
               value: nope
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: two
@@ -64,18 +72,20 @@ cases:
       children:
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: one
           number: '1'
         - type: heading
           depth: 1
-          unnumbered: true
+          numbered: false
           children:
             - type: text
               value: nope
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: two
@@ -86,37 +96,43 @@ cases:
       children:
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: one
         - type: heading
           depth: 2
+          numbered: true
           children:
             - type: text
               value: one.one
         - type: heading
           depth: 5
+          numbered: true
           children:
             - type: text
               value: one.one.one
         - type: heading
           depth: 5
+          numbered: true
           children:
             - type: text
               value: one.one.two
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: two
         - type: heading
           depth: 4
-          unnumbered: true
+          numbered: false
           children:
             - type: text
               value: nope
         - type: heading
           depth: 5
+          numbered: true
           children:
             - type: text
               value: two.zero.one
@@ -125,42 +141,48 @@ cases:
       children:
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: one
           number: '1'
         - type: heading
           depth: 2
+          numbered: true
           children:
             - type: text
               value: one.one
           number: '1.1'
         - type: heading
           depth: 5
+          numbered: true
           children:
             - type: text
               value: one.one.one
           number: '1.1.1'
         - type: heading
           depth: 5
+          numbered: true
           children:
             - type: text
               value: one.one.two
           number: '1.1.2'
         - type: heading
           depth: 1
+          numbered: true
           children:
             - type: text
               value: two
           number: '2'
         - type: heading
           depth: 4
-          unnumbered: true
+          numbered: false
           children:
             - type: text
               value: nope
         - type: heading
           depth: 5
+          numbered: true
           children:
             - type: text
               value: two.zero.one
@@ -171,22 +193,26 @@ cases:
       children:
         - type: math
           value: Ax = b
+          numbered: true
         - type: math
           value: Cx = d
-          unnumbered: true
+          numbered: false
         - type: math
           value: Fx = g
+          numbered: true
     after:
       type: root
       children:
         - type: math
           value: Ax = b
+          numbered: true
           number: '1'
         - type: math
           value: Cx = d
-          unnumbered: true
+          numbered: false
         - type: math
           value: Fx = g
+          numbered: true
           number: '2'
   - title: math numbering - inside directive
     before:
@@ -198,12 +224,14 @@ cases:
           children:
             - type: math
               value: Ax = b
+              numbered: true
         - type: mystDirective
           kind: math
           value: Cx = d
           children:
             - type: math
               value: Cx = d
+              numbered: true
     after:
       type: root
       children:
@@ -213,6 +241,7 @@ cases:
           children:
             - type: math
               value: Ax = b
+              numbered: true
               number: '1'
         - type: mystDirective
           kind: math
@@ -220,6 +249,7 @@ cases:
           children:
             - type: math
               value: Cx = d
+              numbered: true
               number: '2'
   - title: container numbering
     before:
@@ -235,6 +265,7 @@ cases:
           children:
             - type: container
               kind: figure
+              numbered: true
               children:
                 - type: image
                   url: https://via.placeholder.com/150
@@ -252,6 +283,7 @@ cases:
                           value: Something! A legend!?
         - type: container
           kind: figure
+          numbered: true
           children:
             - type: image
               url: https://via.placeholder.com/150
@@ -322,9 +354,8 @@ cases:
           kind: table
           identifier: my-table
           label: my-table
-          numbered: true
           class: myclass
-          unnumbered: true
+          numbered: false
           children:
             - type: caption
               children:
@@ -375,6 +406,7 @@ cases:
           children:
             - type: container
               kind: figure
+              numbered: true
               children:
                 - type: image
                   url: https://via.placeholder.com/150
@@ -393,6 +425,7 @@ cases:
               number: '1'
         - type: container
           kind: figure
+          numbered: true
           children:
             - type: image
               url: https://via.placeholder.com/150
@@ -465,9 +498,8 @@ cases:
           kind: table
           identifier: my-table
           label: my-table
-          numbered: true
           class: myclass
-          unnumbered: true
+          numbered: false
           children:
             - type: caption
               children:

--- a/tests/transforms/addnumbers.yml
+++ b/tests/transforms/addnumbers.yml
@@ -1,0 +1,507 @@
+cases:
+  - title: heading numbering
+    before:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: three
+    after:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+          number: '1'
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+          number: '2'
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: three
+          number: '3'
+  - title: heading numbering - unnumbered
+    before:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+        - type: heading
+          depth: 1
+          unnumbered: true
+          children:
+            - type: text
+              value: nope
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+    after:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+          number: '1'
+        - type: heading
+          depth: 1
+          unnumbered: true
+          children:
+            - type: text
+              value: nope
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+          number: '2'
+  - title: heading numbering - levels
+    before:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+        - type: heading
+          depth: 2
+          children:
+            - type: text
+              value: one.one
+        - type: heading
+          depth: 5
+          children:
+            - type: text
+              value: one.one.one
+        - type: heading
+          depth: 5
+          children:
+            - type: text
+              value: one.one.two
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+        - type: heading
+          depth: 4
+          unnumbered: true
+          children:
+            - type: text
+              value: nope
+        - type: heading
+          depth: 5
+          children:
+            - type: text
+              value: two.zero.one
+    after:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+          number: '1'
+        - type: heading
+          depth: 2
+          children:
+            - type: text
+              value: one.one
+          number: '1.1'
+        - type: heading
+          depth: 5
+          children:
+            - type: text
+              value: one.one.one
+          number: '1.1.1'
+        - type: heading
+          depth: 5
+          children:
+            - type: text
+              value: one.one.two
+          number: '1.1.2'
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+          number: '2'
+        - type: heading
+          depth: 4
+          unnumbered: true
+          children:
+            - type: text
+              value: nope
+        - type: heading
+          depth: 5
+          children:
+            - type: text
+              value: two.zero.one
+          number: '2.0.1'
+  - title: math numbering
+    before:
+      type: root
+      children:
+        - type: math
+          value: Ax = b
+        - type: math
+          value: Cx = d
+          unnumbered: true
+        - type: math
+          value: Fx = g
+    after:
+      type: root
+      children:
+        - type: math
+          value: Ax = b
+          number: '1'
+        - type: math
+          value: Cx = d
+          unnumbered: true
+        - type: math
+          value: Fx = g
+          number: '2'
+  - title: math numbering - inside directive
+    before:
+      type: root
+      children:
+        - type: mystDirective
+          kind: math
+          value: Ax = b
+          children:
+            - type: math
+              value: Ax = b
+        - type: mystDirective
+          kind: math
+          value: Cx = d
+          children:
+            - type: math
+              value: Cx = d
+    after:
+      type: root
+      children:
+        - type: mystDirective
+          kind: math
+          value: Ax = b
+          children:
+            - type: math
+              value: Ax = b
+              number: '1'
+        - type: mystDirective
+          kind: math
+          value: Cx = d
+          children:
+            - type: math
+              value: Cx = d
+              number: '2'
+  - title: container numbering
+    before:
+      type: root
+      children:
+        - type: mystDirective
+          kind: figure
+          args: https://via.placeholder.com/150
+          value: |-
+            This is the figure caption!
+
+            Something! A legend!?
+          children:
+            - type: container
+              kind: figure
+              children:
+                - type: image
+                  url: https://via.placeholder.com/150
+                - type: caption
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: This is the figure caption!
+                - type: legend
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: Something! A legend!?
+        - type: container
+          kind: figure
+          children:
+            - type: image
+              url: https://via.placeholder.com/150
+            - type: caption
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: This is the figure caption!
+        - type: mystDirective
+          kind: list-table
+          args: Caption *text*
+          options:
+            name: my-table
+            header-rows: 1
+            align: center
+            class: myclass
+          value: |-
+            *   - Head 1, Column 1
+                - Head 1, Column 2
+            *   - Row 1, Column 1
+                - Row 1, Column 2
+          children:
+            - type: container
+              kind: table
+              identifier: my-table
+              label: my-table
+              numbered: true
+              class: myclass
+              children:
+                - type: caption
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: 'Caption '
+                        - type: emphasis
+                          children:
+                            - type: text
+                              value: text
+                - type: table
+                  align: center
+                  children:
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          header: true
+                          children:
+                            - type: text
+                              value: Head 1, Column 1
+                        - type: tableCell
+                          header: true
+                          children:
+                            - type: text
+                              value: Head 1, Column 2
+                        - type: tableCell
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1, Column 1
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1, Column 2
+        - type: container
+          kind: table
+          identifier: my-table
+          label: my-table
+          numbered: true
+          class: myclass
+          unnumbered: true
+          children:
+            - type: caption
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: 'Caption '
+                    - type: emphasis
+                      children:
+                        - type: text
+                          value: text
+            - type: table
+              align: center
+              children:
+                - type: tableRow
+                  children:
+                    - type: tableCell
+                      header: true
+                      children:
+                        - type: text
+                          value: Head 1, Column 1
+                    - type: tableCell
+                      header: true
+                      children:
+                        - type: text
+                          value: Head 1, Column 2
+                    - type: tableCell
+                - type: tableRow
+                  children:
+                    - type: tableCell
+                      children:
+                        - type: text
+                          value: Row 1, Column 1
+                    - type: tableCell
+                      children:
+                        - type: text
+                          value: Row 1, Column 2
+    after:
+      type: root
+      children:
+        - type: mystDirective
+          kind: figure
+          args: https://via.placeholder.com/150
+          value: |-
+            This is the figure caption!
+
+            Something! A legend!?
+          children:
+            - type: container
+              kind: figure
+              children:
+                - type: image
+                  url: https://via.placeholder.com/150
+                - type: caption
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: This is the figure caption!
+                - type: legend
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: Something! A legend!?
+              number: '1'
+        - type: container
+          kind: figure
+          children:
+            - type: image
+              url: https://via.placeholder.com/150
+            - type: caption
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: This is the figure caption!
+          number: '2'
+        - type: mystDirective
+          kind: list-table
+          args: Caption *text*
+          options:
+            name: my-table
+            header-rows: 1
+            align: center
+            class: myclass
+          value: |-
+            *   - Head 1, Column 1
+                - Head 1, Column 2
+            *   - Row 1, Column 1
+                - Row 1, Column 2
+          children:
+            - type: container
+              kind: table
+              identifier: my-table
+              label: my-table
+              numbered: true
+              class: myclass
+              children:
+                - type: caption
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: 'Caption '
+                        - type: emphasis
+                          children:
+                            - type: text
+                              value: text
+                - type: table
+                  align: center
+                  children:
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          header: true
+                          children:
+                            - type: text
+                              value: Head 1, Column 1
+                        - type: tableCell
+                          header: true
+                          children:
+                            - type: text
+                              value: Head 1, Column 2
+                        - type: tableCell
+                    - type: tableRow
+                      children:
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1, Column 1
+                        - type: tableCell
+                          children:
+                            - type: text
+                              value: Row 1, Column 2
+              number: '1'
+        - type: container
+          kind: table
+          identifier: my-table
+          label: my-table
+          numbered: true
+          class: myclass
+          unnumbered: true
+          children:
+            - type: caption
+              children:
+                - type: paragraph
+                  children:
+                    - type: text
+                      value: 'Caption '
+                    - type: emphasis
+                      children:
+                        - type: text
+                          value: text
+            - type: table
+              align: center
+              children:
+                - type: tableRow
+                  children:
+                    - type: tableCell
+                      header: true
+                      children:
+                        - type: text
+                          value: Head 1, Column 1
+                    - type: tableCell
+                      header: true
+                      children:
+                        - type: text
+                          value: Head 1, Column 2
+                    - type: tableCell
+                - type: tableRow
+                  children:
+                    - type: tableCell
+                      children:
+                        - type: text
+                          value: Row 1, Column 1
+                    - type: tableCell
+                      children:
+                        - type: text
+                          value: Row 1, Column 2

--- a/tests/transforms/converthtml.spec.ts
+++ b/tests/transforms/converthtml.spec.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { Root } from 'mdast';
+import { convertHtmlToMdast, State } from '../../src';
+
+type TestFile = {
+  cases: TestCase[];
+};
+type TestCase = {
+  title: string;
+  before: Root;
+  after: Root;
+};
+
+const directory = path.join('tests', 'transforms');
+const file = 'converthtml.yml';
+
+const testYaml = fs.readFileSync(path.join(directory, file)).toString();
+const cases = (yaml.load(testYaml) as TestFile).cases;
+
+describe('convertHtmlToMdast', () => {
+  test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
+    '%s',
+    (_, { before, after }) => {
+      const transformed = convertHtmlToMdast(before as Root);
+      expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
+    },
+  );
+});

--- a/tests/transforms/converthtml.yml
+++ b/tests/transforms/converthtml.yml
@@ -1,0 +1,44 @@
+cases:
+  - title: paragraph
+    before:
+      type: root
+      children:
+        - type: html
+          value: <div><p>*some text*</p></div>
+    after:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: '*some text*'
+  - title: style
+    before:
+      type: root
+      children:
+        - type: html
+          value: <div><p><em>some text</em></p></div>
+    after:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: emphasis
+              children:
+                - type: text
+                  value: some text
+  - title: image
+    before:
+      type: root
+      children:
+        - type: html
+          value: <img src="example.jpg" title="example">
+    after:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: image
+              url: example.jpg
+              title: example
+              alt: ''


### PR DESCRIPTION
This transform turns all HTML nodes in a tree to mdast, e.g.

```yaml
before:
  type: root
  children:
    - type: html
      value: <img src="example.jpg" title="example">
after:
  type: root
  children:
    - type: paragraph
      children:
        - type: image
          url: example.jpg
          title: example
          alt: ''
```