### PR TITLE
Add option to not update enumerator values when counting targets

### DIFF
--- a/src/mdast/state.ts
+++ b/src/mdast/state.ts
@@ -30,9 +30,9 @@ type TargetCounts = {
 } & Record<string, number>;
 
 export type EnumeratorOptions = {
-  noHeadingEnumeration?: boolean;
-  noContainerEnumeration?: boolean;
-  noEquationEnumeration?: boolean;
+  disableHeadingEnumeration?: boolean;
+  disableContainerEnumeration?: boolean;
+  disableEquationEnumeration?: boolean;
 };
 
 /**
@@ -200,13 +200,13 @@ export class State {
 
 export const enumerateTargets = (state: State, tree: Root, opts: EnumeratorOptions) => {
   state.initializeNumberedHeadingDepths(tree);
-  if (!opts.noContainerEnumeration) {
+  if (!opts.disableContainerEnumeration) {
     visit(tree, 'container', (node: GenericNode) => state.addTarget(node));
   }
-  if (!opts.noEquationEnumeration) {
+  if (!opts.disableEquationEnumeration) {
     visit(tree, 'math', (node: GenericNode) => state.addTarget(node));
   }
-  if (!opts.noHeadingEnumeration) {
+  if (!opts.disableHeadingEnumeration) {
     visit(tree, 'heading', (node) => state.addTarget(node as GenericNode));
   }
   return tree;

--- a/src/mdast/state.ts
+++ b/src/mdast/state.ts
@@ -91,13 +91,13 @@ export class State {
     this.targets = targets || {};
   }
 
-  addTarget(node: GenericNode) {
+  addTarget(node: GenericNode, updateEnumeratorValues = true) {
     const kind = kindFromNode(node);
     if (kind && kind in TargetKind) {
       let enumerator = null;
       if (node.enumerated !== false) {
         enumerator = this.incrementCount(node, kind as TargetKind);
-        node.enumerator = enumerator;
+        if (updateEnumeratorValues) node.enumerator = enumerator;
       }
       if (node.identifier) {
         this.targets[node.identifier] = {
@@ -194,11 +194,21 @@ export class State {
   }
 }
 
-export const addEnumeratorsToNodes = (state: State, tree: Root) => {
+export const enumerateTargets = (
+  state: State,
+  tree: Root,
+  updateEnumeratorValues = true,
+) => {
   state.initializeNumberedHeadingDepths(tree);
-  visit(tree, 'container', (node: GenericNode) => state.addTarget(node));
-  visit(tree, 'math', (node: GenericNode) => state.addTarget(node));
-  visit(tree, 'heading', (node) => state.addTarget(node as GenericNode));
+  visit(tree, 'container', (node: GenericNode) =>
+    state.addTarget(node, updateEnumeratorValues),
+  );
+  visit(tree, 'math', (node: GenericNode) =>
+    state.addTarget(node, updateEnumeratorValues),
+  );
+  visit(tree, 'heading', (node) =>
+    state.addTarget(node as GenericNode, updateEnumeratorValues),
+  );
   return tree;
 };
 

--- a/src/mdast/transforms.ts
+++ b/src/mdast/transforms.ts
@@ -7,18 +7,19 @@ import { remove } from 'unist-util-remove';
 import { map } from 'unist-util-map';
 import { Admonition, AdmonitionKind, GenericNode } from './types';
 import { admonitionKindToTitle, normalizeLabel } from './utils';
-import { State, enumerateTargets, resolveReferences } from './state';
+import { EnumeratorOptions, State, enumerateTargets, resolveReferences } from './state';
 
 export type Options = {
   addAdmonitionHeaders?: boolean;
   addContainerCaptionNumbers?: boolean;
-  updateEnumeratorValues?: boolean;
-};
+} & EnumeratorOptions;
 
-const defaultOptions: Record<keyof Options, true> = {
+const defaultOptions: Record<keyof Options, boolean> = {
   addAdmonitionHeaders: true,
   addContainerCaptionNumbers: true,
-  updateEnumeratorValues: true,
+  noHeadingEnumeration: false,
+  noContainerEnumeration: false,
+  noEquationEnumeration: false,
 };
 
 // Visit all admonitions and add headers if necessary
@@ -40,7 +41,7 @@ export function addContainerCaptionNumbers(tree: Root, state: State) {
   selectAll('container', tree)
     .filter((container: GenericNode) => container.enumerator !== false)
     .forEach((container: GenericNode) => {
-      const enumerator = state.getTarget(container.identifier)?.enumerator;
+      const enumerator = state.getTarget(container.identifier)?.node.enumerator;
       const para = select('caption > paragraph', container) as GenericNode;
       if (enumerator && para) {
         para.children = [
@@ -111,7 +112,7 @@ export const transform: Plugin<[State, Options?], string, Root> =
     };
     ensureCaptionIsParagraph(tree);
     propagateTargets(tree);
-    enumerateTargets(state, tree, opts.updateEnumeratorValues);
+    enumerateTargets(state, tree, opts);
     resolveReferences(state, tree);
     liftChildren(tree, 'mystDirective');
     liftChildren(tree, 'mystRole');

--- a/src/mdast/transforms.ts
+++ b/src/mdast/transforms.ts
@@ -17,9 +17,9 @@ export type Options = {
 const defaultOptions: Record<keyof Options, boolean> = {
   addAdmonitionHeaders: true,
   addContainerCaptionNumbers: true,
-  noHeadingEnumeration: false,
-  noContainerEnumeration: false,
-  noEquationEnumeration: false,
+  disableHeadingEnumeration: false,
+  disableContainerEnumeration: false,
+  disableEquationEnumeration: false,
 };
 
 // Visit all admonitions and add headers if necessary

--- a/src/mdast/transforms.ts
+++ b/src/mdast/transforms.ts
@@ -7,16 +7,18 @@ import { remove } from 'unist-util-remove';
 import { map } from 'unist-util-map';
 import { Admonition, AdmonitionKind, GenericNode } from './types';
 import { admonitionKindToTitle, normalizeLabel } from './utils';
-import { State, addEnumeratorsToNodes, resolveReferences } from './state';
+import { State, enumerateTargets, resolveReferences } from './state';
 
 export type Options = {
   addAdmonitionHeaders?: boolean;
   addContainerCaptionNumbers?: boolean;
+  updateEnumeratorValues?: boolean;
 };
 
 const defaultOptions: Record<keyof Options, true> = {
   addAdmonitionHeaders: true,
   addContainerCaptionNumbers: true,
+  updateEnumeratorValues: true,
 };
 
 // Visit all admonitions and add headers if necessary
@@ -109,7 +111,7 @@ export const transform: Plugin<[State, Options?], string, Root> =
     };
     ensureCaptionIsParagraph(tree);
     propagateTargets(tree);
-    addEnumeratorsToNodes(state, tree);
+    enumerateTargets(state, tree, opts.updateEnumeratorValues);
     resolveReferences(state, tree);
     liftChildren(tree, 'mystDirective');
     liftChildren(tree, 'mystRole');

--- a/tests/transforms/addenumerators.spec.ts
+++ b/tests/transforms/addenumerators.spec.ts
@@ -11,6 +11,7 @@ type TestCase = {
   title: string;
   before: Root;
   after: Root;
+  opts?: Record<string, boolean>;
 };
 
 const directory = path.join('tests', 'transforms');
@@ -22,8 +23,8 @@ const cases = (yaml.load(testYaml) as TestFile).cases;
 describe('enumerateTargets', () => {
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
-    (_, { before, after }) => {
-      const transformed = enumerateTargets(new State(), before as Root);
+    (_, { before, after, opts }) => {
+      const transformed = enumerateTargets(new State(), before as Root, opts || {});
       expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
     },
   );

--- a/tests/transforms/addenumerators.spec.ts
+++ b/tests/transforms/addenumerators.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 import { Root } from 'mdast';
-import { addEnumeratorsToNodes, State } from '../../src';
+import { enumerateTargets, State } from '../../src';
 
 type TestFile = {
   cases: TestCase[];
@@ -19,11 +19,11 @@ const file = 'addenumerators.yml';
 const testYaml = fs.readFileSync(path.join(directory, file)).toString();
 const cases = (yaml.load(testYaml) as TestFile).cases;
 
-describe('addEnumeratorsToNodes', () => {
+describe('enumerateTargets', () => {
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
     (_, { before, after }) => {
-      const transformed = addEnumeratorsToNodes(new State(), before as Root);
+      const transformed = enumerateTargets(new State(), before as Root);
       expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
     },
   );

--- a/tests/transforms/addenumerators.yml
+++ b/tests/transforms/addenumerators.yml
@@ -165,6 +165,45 @@ cases:
             - type: text
               value: two.zero.one
           enumerator: '2.0.1'
+  - title: heading numbering - disabled
+    opts:
+      disableHeadingEnumeration: true
+    before:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: three
+    after:
+      type: root
+      children:
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: one
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: two
+        - type: heading
+          depth: 1
+          children:
+            - type: text
+              value: three
   - title: math numbering
     before:
       type: root
@@ -189,6 +228,8 @@ cases:
           value: Fx = g
           enumerator: '2'
   - title: math numbering - inside directive
+    opts:
+      disableEquationEnumeration: false
     before:
       type: root
       children:
@@ -221,6 +262,29 @@ cases:
             - type: math
               value: Cx = d
               enumerator: '2'
+  - title: math numbering - disabled
+    opts:
+      disableEquationEnumeration: true
+    before:
+      type: root
+      children:
+        - type: math
+          value: Ax = b
+        - type: math
+          value: Cx = d
+          enumerated: false
+        - type: math
+          value: Fx = g
+    after:
+      type: root
+      children:
+        - type: math
+          value: Ax = b
+        - type: math
+          value: Cx = d
+          enumerated: false
+        - type: math
+          value: Fx = g
   - title: container numbering
     before:
       type: root
@@ -501,3 +565,62 @@ cases:
                       children:
                         - type: text
                           value: Row 1, Column 2
+  - title: container numbering - disabled
+    opts:
+      disableContainerEnumeration: true
+    before:
+      type: root
+      children:
+        - type: mystDirective
+          kind: figure
+          args: https://via.placeholder.com/150
+          value: |-
+            This is the figure caption!
+
+            Something! A legend!?
+          children:
+            - type: container
+              kind: figure
+              children:
+                - type: image
+                  url: https://via.placeholder.com/150
+                - type: caption
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: This is the figure caption!
+                - type: legend
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: Something! A legend!?
+    after:
+      type: root
+      children:
+        - type: mystDirective
+          kind: figure
+          args: https://via.placeholder.com/150
+          value: |-
+            This is the figure caption!
+
+            Something! A legend!?
+          children:
+            - type: container
+              kind: figure
+              children:
+                - type: image
+                  url: https://via.placeholder.com/150
+                - type: caption
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: This is the figure caption!
+                - type: legend
+                  children:
+                    - type: paragraph
+                      children:
+                        - type: text
+                          value: Something! A legend!?


### PR DESCRIPTION
~Enumerator value is still saved on the state for reference resolution etc. but now it may be left off the target node.~

3 options to disable heading, figure, and equation enumeration. If enumeration is disabled, numbered references will not be resolved.