### PR TITLE
🧱 Handle html breaks within markdown text

### DIFF
--- a/tests/transforms/converthtml.spec.ts
+++ b/tests/transforms/converthtml.spec.ts
@@ -11,6 +11,7 @@ type TestCase = {
   title: string;
   before: Root;
   after: Root;
+  opts?: Record<string, boolean>;
 };
 
 const directory = path.join('tests', 'transforms');
@@ -22,8 +23,8 @@ const cases = (yaml.load(testYaml) as TestFile).cases;
 describe('convertHtmlToMdast', () => {
   test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
     '%s',
-    (_, { before, after }) => {
-      const transformed = convertHtmlToMdast(before as Root);
+    (_, { before, after, opts }) => {
+      const transformed = convertHtmlToMdast(before as Root, opts || {});
       expect(yaml.dump(transformed)).toEqual(yaml.dump(after));
     },
   );

--- a/tests/transforms/converthtml.yml
+++ b/tests/transforms/converthtml.yml
@@ -95,3 +95,34 @@ cases:
                   children:
                     - type: text
                       value: Linus
+  - title: horizontal rule
+    before:
+      type: root
+      children:
+        - type: html
+          value: <hr />
+    after:
+      type: root
+      children:
+        - type: thematicBreak
+  - title: break
+    before:
+      type: root
+      children:
+        - type: html
+          value: <br />
+    after:
+      type: root
+      children:
+        - type: break
+  - title: break
+    opts:
+      keepBreaks: false
+    before:
+      type: root
+      children:
+        - type: html
+          value: <br />
+    after:
+      type: root
+      children: []


### PR DESCRIPTION
This pr only affects the `convertHtmlToMdast` transform. Markdown documents may have small html snippets inside them, e.g.:

```
# Example

Here is a break<br />in the middle of a paragraph.
```

When we convert these snippets to mdast, however, they are treated as full html documents, in which `html-util-to-mdast` strips leading/trailing `<br />` breaks. https://github.com/syntax-tree/hast-util-to-mdast/blob/50eda792602f44a6576226a4c14143c5fafb0c63/lib/all.js#L26-L44

This PR adds an option to `keepBreaks` which bypasses the underlying break behavior and directly translates `<br />` to a mdast `break` node. By default, `keepBreaks` is true.