### PR TITLE
🔗 Enable linkify in markdownit config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,69 @@
+// Extension of Commonmark default options shipped with markdown-it
+
+export const MARKDOWN_IT_CONFIG = {
+  options: {
+    html: true, // Enable HTML tags in source
+    xhtmlOut: true, // Use '/' to close single tags (<br />)
+    breaks: false, // Convert '\n' in paragraphs into <br>
+    langPrefix: 'language-', // CSS language prefix for fenced blocks
+    linkify: false, // autoconvert URL-like texts to links
+
+    // Enable some language-neutral replacements + quotes beautification
+    typographer: false,
+
+    // Double + single quotes replacement pairs, when typographer enabled,
+    // and smartquotes on. Could be either a String or an Array.
+    //
+    // For example, you can use '«»„“' for Russian, '„“‚‘' for German,
+    // and ['«\xA0', '\xA0»', '‹\xA0', '\xA0›'] for French (including nbsp).
+    quotes: '\u201c\u201d\u2018\u2019' /* “”‘’ */,
+
+    // Highlighter function. Should return escaped HTML,
+    // or '' if the source string is not changed and should be escaped externaly.
+    // If result starts with <pre... internal wrapper is skipped.
+    //
+    // function (/*str, lang*/) { return ''; }
+    //
+    highlight: null,
+
+    maxNesting: 20, // Internal protection, recursion limit
+  },
+
+  components: {
+    core: {
+      // Adding 'linkify' here is the only change to the MarkdownIt commonmark preset config
+      rules: ['normalize', 'block', 'inline', 'linkify'],
+    },
+
+    block: {
+      rules: [
+        'blockquote',
+        'code',
+        'fence',
+        'heading',
+        'hr',
+        'html_block',
+        'lheading',
+        'list',
+        'reference',
+        'paragraph',
+      ],
+    },
+
+    inline: {
+      rules: [
+        'autolink',
+        'backticks',
+        'emphasis',
+        'entity',
+        'escape',
+        'html_inline',
+        'image',
+        'link',
+        'newline',
+        'text',
+      ],
+      rules2: ['balance_pairs', 'emphasis', 'text_collapse'],
+    },
+  },
+};

--- a/src/myst.ts
+++ b/src/myst.ts
@@ -1,4 +1,11 @@
 import MarkdownIt from 'markdown-it';
+import { Root } from 'mdast';
+import type { Plugin } from 'unified';
+import { unified } from 'unified';
+import rehypeStringify from 'rehype-stringify';
+import { directivesDefault, rolesDefault } from 'markdown-it-docutils';
+import { MARKDOWN_IT_CONFIG } from './config';
+import { formatHtml, mystToHast, tokensToMyst, transform, State } from './mdast';
 import {
   mathPlugin,
   convertFrontMatter,
@@ -9,13 +16,7 @@ import {
   deflistPlugin,
   tasklistPlugin,
 } from './plugins';
-import { Root } from 'mdast';
-import type { Plugin } from 'unified';
-import { formatHtml, mystToHast, tokensToMyst, transform, State } from './mdast';
-import { unified } from 'unified';
-import rehypeStringify from 'rehype-stringify';
 import type { AllOptions, Options } from './types';
-import { directivesDefault, rolesDefault } from 'markdown-it-docutils';
 
 export type { Options, IRole, IDirective } from './types';
 
@@ -104,7 +105,7 @@ export class MyST {
 
   _createTokenizer() {
     const exts = this.opts.extensions;
-    const tokenizer = MarkdownIt('commonmark', this.opts.markdownit);
+    const tokenizer = MarkdownIt(MARKDOWN_IT_CONFIG as any, this.opts.markdownit);
     if (exts.tables) tokenizer.enable('table');
     if (exts.frontmatter)
       tokenizer.use(frontMatterPlugin, () => ({})).use(convertFrontMatter);

--- a/tests/linkify.spec.ts
+++ b/tests/linkify.spec.ts
@@ -1,0 +1,103 @@
+import { MyST } from '../src';
+
+describe('linkify', () => {
+  it('linkify in paragraph', () => {
+    const myst = new MyST();
+    const mystLinkify = new MyST({ markdownit: { linkify: true } });
+    const content = 'Link in paragraph: example.com';
+    expect(myst.parse(content)).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', value: 'Link in paragraph: example.com' }],
+        },
+      ],
+    });
+    expect(mystLinkify.parse(content)).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'Link in paragraph: ' },
+            {
+              type: 'link',
+              url: 'http://example.com',
+              children: [{ type: 'text', value: 'example.com' }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+  it('linkify in heading', () => {
+    const myst = new MyST();
+    const mystLinkify = new MyST({ markdownit: { linkify: true } });
+    const content = '# Link in heading: example.com';
+    expect(myst.parse(content)).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'heading',
+          depth: 1,
+          children: [{ type: 'text', value: 'Link in heading: example.com' }],
+        },
+      ],
+    });
+    expect(mystLinkify.parse(content)).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'heading',
+          depth: 1,
+          children: [
+            { type: 'text', value: 'Link in heading: ' },
+            {
+              type: 'link',
+              url: 'http://example.com',
+              children: [{ type: 'text', value: 'example.com' }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+  it('dont linkify in link', () => {
+    const myst = new MyST();
+    const mystLinkify = new MyST({ markdownit: { linkify: true } });
+    const content = 'Link in link: [example.com](https://example.com)';
+    expect(myst.parse(content)).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'Link in link: ' },
+            {
+              type: 'link',
+              url: 'https://example.com',
+              children: [{ type: 'text', value: 'example.com' }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(mystLinkify.parse(content)).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'Link in link: ' },
+            {
+              type: 'link',
+              url: 'https://example.com',
+              children: [{ type: 'text', value: 'example.com' }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Previously setting `linkify: true` in `MarkdownIt` options had no effect since it was disabled at the config level. Now, it's enabled at the config level (though still must be set to 'true' in options).

`config.ts` is copied from here: https://github.com/markdown-it/markdown-it/blob/12.3.2/lib/presets/commonmark.js and only `'linkify'` is added to `core.rules`