### PR TITLE
Include a bundle for mystjs that works with jest

### DIFF
--- a/packages/citation-js-utils/package.json
+++ b/packages/citation-js-utils/package.json
@@ -4,7 +4,6 @@
   "description": "Utilities for citation-js.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "unpkg": "dist/index.umd.min.js",
   "types": "dist/types/index.d.ts",
   "files": [
     "src",

--- a/packages/jtex/package.json
+++ b/packages/jtex/package.json
@@ -4,7 +4,6 @@
   "description": "Tool for rendering LaTeX documents from jinja-style templates",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "unpkg": "dist/index.umd.min.js",
   "types": "dist/types/index.d.ts",
   "files": [
     "src",

--- a/packages/mystjs/README.md
+++ b/packages/mystjs/README.md
@@ -117,7 +117,8 @@ The scripts for building, testing, and serving the project are in the [package.j
 
 ### `npm run build`
 
-Builds the library, including compiling the typescript and bundling/minification to create `index.cjs.js`. Which can be helpful for tooling (e.g. `jest`) that can struggle with esm modules.
+Builds the library, including compiling the typescript and bundling/minification to create `index.umd.min.js` which can be used in the browser directly.
+Additionally, `index.cjs.js` is created which bundles ESM dependencies like `unified`, which can be helpful for tooling (e.g. `jest`) that can struggle with ESM modules.
 This outputs to the `dist` folder, and also includes all type definitions (`*.d.ts`) in the types folder.
 
 ### `npm run test`

--- a/packages/mystjs/README.md
+++ b/packages/mystjs/README.md
@@ -117,8 +117,8 @@ The scripts for building, testing, and serving the project are in the [package.j
 
 ### `npm run build`
 
-Builds the library, including compiling the typescript and bundling/minification to create `index.umd.min.js`.
-This outputs to the `dist` folder, and also includes all type definitions (`*.d.ts`).
+Builds the library, including compiling the typescript and bundling/minification to create `index.cjs.js`. Which can be helpful for tooling (e.g. `jest`) that can struggle with esm modules.
+This outputs to the `dist` folder, and also includes all type definitions (`*.d.ts`) in the types folder.
 
 ### `npm run test`
 

--- a/packages/mystjs/docs/Makefile
+++ b/packages/mystjs/docs/Makefile
@@ -7,13 +7,13 @@ fix-default-js:
 
 build:
 	cd ..; npm run build
-	cp ../dist/index.umd.min.js _static/myst.min.js
+	cp ../dist/index.cjs.js _static/myst.min.js
 	jupyter-book build .
 	make fix-default-js
 
 build-watch:
 	jupyter-book build .
-	cp ../dist/index.umd.min.js _build/html/_static/myst.min.js
+	cp ../dist/index.cjs.js _build/html/_static/myst.min.js
 	make fix-default-js
 
 watch: clean

--- a/packages/mystjs/docs/Makefile
+++ b/packages/mystjs/docs/Makefile
@@ -7,13 +7,13 @@ fix-default-js:
 
 build:
 	cd ..; npm run build
-	cp ../dist/index.cjs.js _static/myst.min.js
+	cp ../dist/index.umd.min.js _static/myst.min.js
 	jupyter-book build .
 	make fix-default-js
 
 build-watch:
 	jupyter-book build .
-	cp ../dist/index.cjs.js _build/html/_static/myst.min.js
+	cp ../dist/index.umd.min.js _build/html/_static/myst.min.js
 	make fix-default-js
 
 watch: clean

--- a/packages/mystjs/package.json
+++ b/packages/mystjs/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "unpkg": "dist/index.cjs.js",
+  "unpkg": "dist/index.umd.min.js",
   "types": "dist/types/index.d.ts",
   "files": [
     "dist"
@@ -33,11 +33,12 @@
     "test:watch": "jest --watchAll",
     "lint": "eslint \"src/**/*.ts\" -c .eslintrc.js",
     "lint:format": "prettier --check src/*.ts src/**/*.ts",
-    "build:bundle": "esbuild src/index.ts --bundle --outfile=dist/index.cjs.js --platform=node",
+    "build:bundle:cjs": "esbuild src/index.ts --bundle --outfile=dist/index.cjs.js --platform=node",
+    "build:bundle:browser": "esbuild src/index.ts --bundle --outfile=dist/index.umd.min.js --platform=browser --minify",
     "build:esm": "tsc --module es2015   --outDir dist/esm",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs",
     "declarations": "tsc --declaration --emitDeclarationOnly --outDir dist/types",
-    "build": "npm-run-all -l clean -p build:cjs build:esm build:bundle declarations"
+    "build": "npm-run-all -l clean -p build:cjs build:esm build:bundle:browser build:bundle:cjs declarations"
   },
   "bugs": {
     "url": "https://github.com/executablebooks/mystjs/issues"

--- a/packages/mystjs/package.json
+++ b/packages/mystjs/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "unpkg": "dist/index.umd.min.js",
+  "unpkg": "dist/index.cjs.js",
   "types": "dist/types/index.d.ts",
   "files": [
     "dist"
@@ -33,7 +33,7 @@
     "test:watch": "jest --watchAll",
     "lint": "eslint \"src/**/*.ts\" -c .eslintrc.js",
     "lint:format": "prettier --check src/*.ts src/**/*.ts",
-    "build:bundle": "esbuild src/index.ts --bundle --outfile=dist/index.umd.min.js --platform=browser",
+    "build:bundle": "esbuild src/index.ts --bundle --outfile=dist/index.cjs.js --platform=node",
     "build:esm": "tsc --module es2015   --outDir dist/esm",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs",
     "declarations": "tsc --declaration --emitDeclarationOnly --outDir dist/types",


### PR DESCRIPTION
This fixes a downstream packaging issue with mystjs to allow it to work in an easier way with jest.