### PR TITLE
💇‍♀️ Modify extractPart: support multiple parts, no longer support tags

### DIFF
--- a/packages/myst-cli/src/build/tex/single.spec.ts
+++ b/packages/myst-cli/src/build/tex/single.spec.ts
@@ -18,17 +18,17 @@ describe('extractPart', () => {
       children: [
         {
           type: 'block' as any,
-          data: { tags: ['other_tag'] },
+          data: { parts: ['other_tag'] },
           children: [{ type: 'text', value: 'untagged content' }],
         },
         {
           type: 'block' as any,
-          data: { tags: ['test_tag'] },
+          data: { parts: ['test_tag'] },
           children: [{ type: 'text', value: 'tagged content' }],
         },
         {
           type: 'block' as any,
-          data: { tags: ['other_tag', 'test_tag'] },
+          data: { parts: ['other_tag', 'test_tag'] },
           children: [{ type: 'text', value: 'also tagged content' }],
         },
       ],
@@ -43,8 +43,13 @@ describe('extractPart', () => {
       children: [
         {
           type: 'block' as any,
-          data: { tags: ['other_tag'] },
+          data: { parts: ['other_tag'] },
           children: [{ type: 'text', value: 'untagged content' }],
+        },
+        {
+          type: 'block' as any,
+          data: { parts: ['other_tag'] },
+          children: [{ type: 'text', value: 'also tagged content' }],
         },
       ],
     });
@@ -55,7 +60,7 @@ describe('extractPart', () => {
       children: [
         {
           type: 'block' as any,
-          data: { tags: ['test_tag'] },
+          data: { parts: ['test_tag'] },
           children: [{ type: 'text', value: 'tagged content' }],
         },
       ],
@@ -74,7 +79,7 @@ describe('extractPart', () => {
       children: [
         {
           type: 'block' as any,
-          data: { tags: ['test_tag'] },
+          data: { parts: ['test_tag'] },
           children: [{ type: 'text', value: 'tagged content' }],
         },
       ],
@@ -91,7 +96,7 @@ describe('extractPart', () => {
       children: [
         {
           type: 'block' as any,
-          data: { tags: ['test_tag'] },
+          data: { parts: ['test_tag'] },
           children: [{ type: 'text', value: 'tagged content' }],
         },
       ],

--- a/packages/myst-common/src/extractParts.spec.ts
+++ b/packages/myst-common/src/extractParts.spec.ts
@@ -16,23 +16,23 @@ describe('extractPart', () => {
       children: [
         {
           type: 'block' as any,
-          data: { tags: ['other_tag'] },
-          children: [{ type: 'text', value: 'untagged content' }],
-        },
-        {
-          type: 'block' as any,
           data: { tags: ['test_tag'] },
           children: [{ type: 'text', value: 'tagged content' }],
         },
         {
           type: 'block' as any,
-          data: { tags: ['other_tag', 'test_tag'] },
-          children: [{ type: 'text', value: 'also tagged content' }],
+          data: { parts: ['other_tag'] },
+          children: [{ type: 'text', value: 'other part content' }],
         },
         {
           type: 'block' as any,
-          data: { part: 'test_tag' },
-          children: [{ type: 'text', value: 'a part' }],
+          data: { parts: ['other_tag', 'test_tag'] },
+          children: [{ type: 'text', value: 'multiple parts' }],
+        },
+        {
+          type: 'block' as any,
+          data: { parts: ['test_tag'] },
+          children: [{ type: 'text', value: 'single part' }],
         },
       ],
     };
@@ -41,18 +41,13 @@ describe('extractPart', () => {
       children: [
         {
           type: 'block' as any,
-          data: { tags: ['test_tag'] },
-          children: [{ type: 'text', value: 'tagged content' }],
+          data: { parts: ['other_tag', 'test_tag'] },
+          children: [{ type: 'text', value: 'multiple parts' }],
         },
         {
           type: 'block' as any,
-          data: { tags: ['other_tag', 'test_tag'] },
-          children: [{ type: 'text', value: 'also tagged content' }],
-        },
-        {
-          type: 'block' as any,
-          data: { part: 'test_tag' },
-          children: [{ type: 'text', value: 'a part' }],
+          data: { parts: ['test_tag'] },
+          children: [{ type: 'text', value: 'single part' }],
         },
       ],
     });
@@ -61,8 +56,18 @@ describe('extractPart', () => {
       children: [
         {
           type: 'block' as any,
-          data: { tags: ['other_tag'] },
-          children: [{ type: 'text', value: 'untagged content' }],
+          data: { tags: ['test_tag'] },
+          children: [{ type: 'text', value: 'tagged content' }],
+        },
+        {
+          type: 'block' as any,
+          data: { parts: ['other_tag'] },
+          children: [{ type: 'text', value: 'other part content' }],
+        },
+        {
+          type: 'block' as any,
+          data: { parts: ['other_tag'] },
+          children: [{ type: 'text', value: 'multiple parts' }],
         },
       ],
     });


### PR DESCRIPTION
`extractParts` is used when building exports for tex templates; if a template requires a specific `part` (e.g. "abstract"), this function finds blocks corresponding to that part and pulls it out of the mdast tree.

Previously, this function looked at metadata `tags` and `part`. If either of those included the desired part, the block was removed.

Now, this function only looks at metadata `parts`. Also, it no longer removes the block from the source tree if there are multiple `parts` (this means a single block could potentially populate multiple parts of a tex template - certainly an edge case, but better than deleting a block when additional `parts` metadata is still present and unused).