### PR TITLE
Add github code-file link previews

### DIFF
--- a/.changeset/breezy-candles-pull.md
+++ b/.changeset/breezy-candles-pull.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'myst-transforms': patch
+---
+
+Introduce GithubTransformer for file links.

--- a/docs/creating-pdf-documents.md
+++ b/docs/creating-pdf-documents.md
@@ -106,7 +106,7 @@ myst templates list --pdf --tag two-column
 
 Once you have found a template, you can list detailed information about the parts and options that the template exposes using:
 
-```
+```bash
 myst templates arxiv_two_column
 
 > ID: public/arxiv_two_column

--- a/docs/external-references.md
+++ b/docs/external-references.md
@@ -9,9 +9,10 @@ External references are references to structured content or documents that are o
 MyST supports referencing rich content in a growing number of formats, including:
 
 1. other `mystjs` projects, with rich cross-linking of content
-2. integrating directly with Wikipedia articles to show tooltips,
-3. linking to other Sphinx documentation using intersphinx,
-4. showing structured content from scholarly sources like DOIs or RRIDs.
+1. integrating directly with **Wikipedia** articles to show tooltips,
+1. linking to other **Sphinx** documentation using intersphinx,
+1. link to files on **GitHub** and show inline previews,
+1. showing structured content from scholarly sources like **DOIs** or **RRIDs**.
 
 ```{seealso}
 [](./cross-references.md) for referencing content in your project and [](./citations.md) to cite scholarly work and create bibliographies.
@@ -148,7 +149,7 @@ Note that if the page title has spaces in it, simply replace them with underscor
 :class: dropdown
 # Different languages or wikis
 
-There are many different official and unoffial wikis that use the same [Wikimedia](wiki:Wikimedia_Foundation) technology, including subdomains in various langauges.
+There are many different official and unofficial wikis that use the same [Wikimedia](wiki:Wikimedia_Foundation) technology, including subdomains in various langauges.
 
 Wikipedia links, like `https://fr.wikipedia.org/wiki/Croissant_(viennoiserie)` will work fine out of the box, and point to [](https://fr.wikipedia.org/wiki/Croissant_(viennoiserie)) with the popup still working!
 
@@ -166,12 +167,14 @@ MyST can directly integrate with links to GitHub to create hover-card informatio
 # Creating GitHub links to code
 GitHub links to code can be generated on the GitHub web application when browsing code and click on the line numbers, then copy the URL. To select multiple lines, click your first line then shift-click to select multiple lines, the URL will be updated to end with `#L4-L6`. The structure of the link should look like:
 
-```
-https://github.com/{{org}}/{{repo}}/blob/{{reference}}/file.py#L12-L28
+```text
+https://github.com/{{org}}/{{repo}}/blob/{{reference}}/file.py#L4-L6
 ```
 
 Any git `reference` will work, however, picking a branch like `main` may mean that your code line numbers will change, instead, you may want to go to navigate to a specific git commit or tag, which will show up in the URL.
 ````
+
+% TODO: Add ability to reference issues and PRs with queries for the issue names, and PR information.
 
 ## Linking DOIs
 

--- a/docs/external-references.md
+++ b/docs/external-references.md
@@ -157,6 +157,22 @@ Wikipedia links, like `https://fr.wikipedia.org/wiki/Croissant_(viennoiserie)` w
 % TODO: Set the default wiki links, or an additional wiki link in references, e.g. to something like https://wiki.seg.org/wiki/Knowledge_tree
 ```
 
+## GitHub Links
+
+MyST can directly integrate with links to GitHub to create hover-card information directly integrated into your MyST documents. For example, a link to the [linkTransforms](https://github.com/executablebooks/mystjs/blob/78d16ee1a/packages/myst-transforms/src/links/plugin.ts#L12-L28) plugin code shows a preview of the code. The code preview works for both mutliple line numbers and higlighting [single lines](https://github.com/executablebooks/mystjs/blob/78d16ee1a/packages/myst-transforms/src/links/plugin.ts#L30), which shows the surrounding ten lines, with the referenced line highlighted. If you reference the [full file](https://github.com/executablebooks/mystjs/blob/78d16ee1a/packages/myst-transforms/src/links/plugin.ts) then the first ten lines of the file are shown in the preview.
+
+````{important}
+:class: dropdown
+# Creating GitHub links to code
+GitHub links to code can be generated on the GitHub web application when browsing code and click on the line numbers, then copy the URL. To select multiple lines, click your first line then shift-click to select multiple lines, the URL will be updated to end with `#L4-L6`. The structure of the link should look like:
+
+```
+https://github.com/{{org}}/{{repo}}/blob/{{reference}}/file.py#L12-L28
+```
+
+Any git `reference` will work, however, picking a branch like `main` may mean that your code line numbers will change, instead, you may want to go to navigate to a specific git commit or tag, which will show up in the URL.
+````
+
 ## Linking DOIs
 
 It is possible to include DOIs as external content, and they are also added as citations to your project and show up in the references section at the bottom of a document. See [](./citations.md) for more details, specifically [](#doi-links), which explains linking DOIs with the `<doi:10.5281/zenodo.6476040>` or `[](doi:10.5281/zenodo.6476040)` to create a citation, for example (<doi:10.5281/zenodo.6476040>).

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -16,6 +16,7 @@ import {
   linksTransform,
   MystTransformer,
   WikiTransformer,
+  GithubTransformer,
   RRIDTransformer,
   DOITransformer,
 } from 'myst-transforms';
@@ -115,6 +116,7 @@ export async function transformMdast(
   const intersphinx = projectPath ? await loadIntersphinx(session, { projectPath }) : [];
   const transformers = [
     new WikiTransformer(),
+    new GithubTransformer(),
     new RRIDTransformer(),
     new DOITransformer(), // This also is picked up in the next transform
     new MystTransformer(intersphinx),

--- a/packages/myst-transforms/docs/_toc.yml
+++ b/packages/myst-transforms/docs/_toc.yml
@@ -3,4 +3,5 @@ root: index
 chapters:
   - file: overview
   - file: conventions
+  - file: links
   - file: enumeration

--- a/packages/myst-transforms/docs/index.md
+++ b/packages/myst-transforms/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: myst-transforms
-description: myst-transforms is library for converting MyST documents to LaTeX.
+description: myst-transforms contains a number of transformations for MyST ASTs
 ---
 
 [![myst-transforms on npm](https://img.shields.io/npm/v/myst-transforms.svg)](https://www.npmjs.com/package/myst-transforms)

--- a/packages/myst-transforms/docs/links.md
+++ b/packages/myst-transforms/docs/links.md
@@ -1,0 +1,45 @@
+---
+title: Links
+description: Create link transformers for external links that follow specific protocols.
+---
+
+The `myst-transforms` library exposes multiple ways to transform links, for example, resolving DOIs, Wikipedia links, or links to GitHub source code, and external myst protocols for cross-project references (including intersphinx).
+
+```typescript
+import { Inventory } from 'intersphinx';
+import {
+  linksTransform,
+  WikiTransformer,
+  GithubTransformer,
+  RRIDTransformer,
+  DOITransformer,
+  MystTransformer,
+} from 'myst-transforms';
+import { VFile } from 'vfile';
+
+const file = new VFile();
+const intersphinx = [new Inventory({ id: 'python', path: 'https://docs.python.org/3.7' })];
+const transformers = [
+  new WikiTransformer(),
+  new GithubTransformer(),
+  new RRIDTransformer(),
+  new DOITransformer(),
+  new MystTransformer(intersphinx),
+];
+linksTransform(mdast, vfile, { transformers });
+```
+
+`WikiTransformer`
+: The Wikipedia transformer picks up links to any wikipedia page, and can provide a live preview.
+
+`GithubTransformer`
+: The Github transformer allows for previewing of GitHub source files.
+
+`RRIDTransformer`
+: The RRID transformer picks up on RRIDs and allows these to be previewed.
+
+`DOITransformer`
+: The DOI transformer can validate DOIs (using `doi-utils`) and provides interactive previews of citation information.
+
+`MystTransformer`
+: The MyST transformer provides cross-reference links from `intersphinx` inventories and MyST inventories, allowing creation of persistent links between projects.

--- a/packages/myst-transforms/src/links/github.spec.ts
+++ b/packages/myst-transforms/src/links/github.spec.ts
@@ -1,0 +1,43 @@
+import { VFile } from 'vfile';
+import type { Link } from './types';
+import { GithubTransformer } from './github';
+
+describe('Test GithubTransformer', () => {
+  test('any github link', async () => {
+    const file = new VFile();
+    const t = new GithubTransformer();
+    const url =
+      'https://github.com/executablebooks/mystjs/blob/3cdb8ec6/packages/mystjs/src/mdast/state.ts#L32-L36';
+    const raw =
+      'https://raw.githubusercontent.com/executablebooks/mystjs/3cdb8ec6/packages/mystjs/src/mdast/state.ts';
+    const link: Link = {
+      type: 'link',
+      url,
+      children: [],
+    };
+    expect(t.test(link.url)).toBe(true);
+    expect(t.transform(link, file)).toBe(true);
+    expect(link.url).toBe(url);
+    expect(link.children).toEqual([{ type: 'text', value: 'packages/mystjs/src/mdast/state.ts' }]);
+    expect(link.data?.raw).toEqual(raw);
+    expect(link.data?.org).toEqual('executablebooks');
+    expect(link.data?.repo).toEqual('mystjs');
+    expect(link.data?.reference).toEqual('3cdb8ec6');
+    expect(link.data?.file).toEqual('packages/mystjs/src/mdast/state.ts');
+    expect(link.data?.from).toEqual(32);
+    expect(link.data?.to).toEqual(36);
+  });
+  test('dont change other links', () => {
+    const file = new VFile();
+    const t = new GithubTransformer();
+    const url = 'https://github.com/executablebooks/mystjs';
+    const link: Link = {
+      type: 'link',
+      url,
+      children: [],
+    };
+    expect(t.test(link.url)).toBe(true);
+    expect(t.transform(link, file)).toBe(false);
+    expect(link.data).toBeUndefined();
+  });
+});

--- a/packages/myst-transforms/src/links/github.ts
+++ b/packages/myst-transforms/src/links/github.ts
@@ -1,0 +1,82 @@
+import { fileWarn } from 'myst-common';
+import type { VFile } from 'vfile';
+import type { Link, LinkTransformer } from './types';
+import { updateLinkTextIfEmpty, withoutHttp } from './utils';
+
+const RESOLVER = 'https://github.com/';
+const TRANSFORM_SOURCE = 'LinkTransform:Github';
+
+type GithubFileLink = {
+  kind: 'file';
+  org: string;
+  repo: string;
+  /**
+   * This can be a branch name, a tag, or a hash.
+   */
+  reference: string;
+  file: string;
+  from?: number;
+  to?: number;
+};
+
+/**
+ * This takes a url like:
+ *
+ *    https://github.com/executablebooks/mystjs/blob/3cdb8ec6/packages/mystjs/src/mdast/state.ts#L32-L36
+ *
+ * And creates the raw url information to create a github raw url, like:
+ *
+ *    https://raw.githubusercontent.com/executablebooks/mystjs/3cdb8ec6/packages/mystjs/src/mdast/state.ts
+ */
+function parseGithubFile(urlSource: string): undefined | GithubFileLink {
+  const url = new URL(urlSource);
+  if (url.host !== 'github.com') return;
+  const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/(.+)/);
+  if (!match) return;
+  const [, org, repo, reference, file] = match;
+  const lineNumbers = url.hash.match(/L([0-9]+)(?:-L([0-9]+))?/);
+  const [, fromString, toString] = lineNumbers ?? [];
+  const from = fromString ? Number(fromString) : undefined;
+  const to = toString ? Number(toString) : undefined;
+  return {
+    kind: 'file',
+    org,
+    repo,
+    reference,
+    file,
+    from,
+    to,
+  };
+}
+
+function rawUrl(github: GithubFileLink) {
+  return `https://raw.githubusercontent.com/${github.org}/${github.repo}/${github.reference}/${github.file}`;
+}
+
+export class GithubTransformer implements LinkTransformer {
+  protocol = 'github';
+
+  test(uri?: string): boolean {
+    if (!uri) return false;
+    return withoutHttp(uri).startsWith(withoutHttp(RESOLVER));
+  }
+
+  transform(link: Link, file: VFile): boolean {
+    const urlSource = link.urlSource || link.url;
+    const github = parseGithubFile(urlSource);
+    if (!github) {
+      // fileWarn(file, `Found Github url, but couldn't parse it: ${urlSource}`, {
+      //   node: link,
+      //   source: TRANSFORM_SOURCE,
+      // });
+      return false;
+    }
+    link.data = {
+      ...github,
+      raw: rawUrl(github),
+    };
+    link.internal = false;
+    updateLinkTextIfEmpty(link, github.file);
+    return true;
+  }
+}

--- a/packages/myst-transforms/src/links/index.ts
+++ b/packages/myst-transforms/src/links/index.ts
@@ -3,5 +3,6 @@ export { MystTransformer } from './myst';
 export { WikiTransformer } from './wiki';
 export { RRIDTransformer } from './rrid';
 export { DOITransformer } from './doi';
+export { GithubTransformer } from './github';
 export type { LinkTransformer, Link } from './types';
 export { updateLinkTextIfEmpty } from './utils';


### PR DESCRIPTION
Extends the links transformers to recognize github file links.

![github-file-preview](https://user-images.githubusercontent.com/913249/201424959-eac18043-aae9-4aab-8592-f21c72167804.gif)

This is a start of github integration in the themes, and was motivated by being able to pull in typescript documentation where these links are generated automatically. This specific integration doesn't require authentication, and is not rate-limited -- github issues and PRs will likely require authentication, and server-side, run-time components.