### PR TITLE
📦 Deprecate unified exports from mystjs

### DIFF
--- a/.changeset/fast-goats-tie.md
+++ b/.changeset/fast-goats-tie.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'mystjs': patch
+---
+
+Deprecate unified exports from `mystjs`

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -1,6 +1,6 @@
 import type { Root } from 'mdast';
 import type { GenericNode } from 'mystjs';
-import { selectAll } from 'mystjs';
+import { selectAll } from 'unist-util-select';
 import { nanoid } from 'nanoid';
 import type { CellOutput } from '@curvenote/blocks';
 import { ContentFormatTypes, KINDS } from '@curvenote/blocks';

--- a/packages/myst-cli/src/transforms/citations.ts
+++ b/packages/myst-cli/src/transforms/citations.ts
@@ -1,7 +1,7 @@
 import type { CitationRenderer } from 'citation-js-utils';
 import { InlineCite } from 'citation-js-utils';
 import type { StaticPhrasingContent, Parent } from 'myst-spec';
-import { selectAll } from 'mystjs';
+import { selectAll } from 'unist-util-select';
 import type { Logger } from 'myst-cli-utils';
 import type { Root } from 'mdast';
 import type { References } from './types';

--- a/packages/myst-cli/src/transforms/dois.ts
+++ b/packages/myst-cli/src/transforms/dois.ts
@@ -3,7 +3,7 @@ import { getCitations } from 'citation-js-utils';
 import { validate, normalize } from 'doi-utils';
 import type { Link } from 'myst-spec';
 import type { GenericNode } from 'mystjs';
-import { selectAll } from 'mystjs';
+import { selectAll } from 'unist-util-select';
 import fetch from 'node-fetch';
 import { tic } from 'myst-cli-utils';
 import type { Logger } from 'myst-cli-utils';

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import type { Root } from 'mdast';
 import mime from 'mime-types';
 import type { GenericNode } from 'mystjs';
-import { selectAll } from 'mystjs';
+import { selectAll } from 'unist-util-select';
 import fetch from 'node-fetch';
 import path from 'path';
 import type { PageFrontmatter } from 'myst-frontmatter';

--- a/packages/myst-cli/src/transforms/include.ts
+++ b/packages/myst-cli/src/transforms/include.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import type { GenericNode } from 'mystjs';
 import type { Root } from 'mdast';
 import { parseMyst } from '../process';
-import { selectAll } from 'mystjs';
+import { selectAll } from 'unist-util-select';
 import { join, dirname } from 'path';
 import type { ISession } from '../session/types';
 

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import pLimit from 'p-limit';
 import fetch from 'node-fetch';
 import type { GenericNode } from 'mystjs';
-import { selectAll } from 'mystjs';
+import { selectAll } from 'unist-util-select';
 import { updateLinkTextIfEmpty } from 'myst-transforms';
 import type { LinkTransformer, Link } from 'myst-transforms';
 import { fileError } from 'myst-common';

--- a/packages/myst-cli/src/transforms/mdast.ts
+++ b/packages/myst-cli/src/transforms/mdast.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import type { GenericNode } from 'mystjs';
 import type { Root } from 'mdast';
-import { selectAll } from 'mystjs';
+import { selectAll } from 'unist-util-select';
 import { join, dirname } from 'path';
 import type { ISession } from '../session/types';
 

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -1,5 +1,5 @@
 import type { GenericNode } from 'mystjs';
-import { selectAll } from 'mystjs';
+import { selectAll } from 'unist-util-select';
 import type { CellOutput } from '@curvenote/blocks';
 import { minifyCellOutput, walkPaths } from 'nbtx';
 import type { Root } from 'mdast';

--- a/packages/mystjs/src/index.ts
+++ b/packages/mystjs/src/index.ts
@@ -4,8 +4,32 @@ export * from './mdast';
 export * from './myst';
 export { plugins };
 
-export { unified } from 'unified';
-export { select, selectAll } from 'unist-util-select';
-export { map } from 'unist-util-map';
-export { visit } from 'unist-util-visit';
-export { remove } from 'unist-util-remove';
+import { remove } from 'unist-util-remove';
+import { select, selectAll } from 'unist-util-select';
+
+export {
+  /** @deprecated
+   *
+   * Please use:
+   * ```ts
+   * import { remove } from 'unist-util-remove';
+   * ```
+   */
+  remove,
+  /** @deprecated
+   *
+   * Please use:
+   * ```ts
+   * import { select } from 'unist-util-select';
+   * ```
+   */
+  select,
+  /** @deprecated
+   *
+   * Please use:
+   * ```ts
+   * import { selectAll } from 'unist-util-select';
+   * ```
+   */
+  selectAll,
+};

--- a/packages/mystjs/tests/linkify.spec.ts
+++ b/packages/mystjs/tests/linkify.spec.ts
@@ -1,5 +1,6 @@
 import type { Root } from 'mdast';
-import { MyST, visit } from '../src';
+import { visit } from 'unist-util-visit';
+import { MyST } from '../src';
 
 function stripPositions(tree: Root) {
   visit(tree, (node) => {

--- a/packages/mystjs/tests/myst.spec.ts
+++ b/packages/mystjs/tests/myst.spec.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
-import { MyST, visit } from '../src';
+import { visit } from 'unist-util-visit';
+import { MyST } from '../src';
 import type { Root } from 'mdast';
 
 type TestFile = {


### PR DESCRIPTION
This removes the unist exports from mystjs, these were included to get around CJS/ESM issues in jest primarily, and there are better ways to do that!