### PR TITLE
🐛 Relative paths should be '.' if the same

### DIFF
--- a/.changeset/late-singers-cross.md
+++ b/.changeset/late-singers-cross.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Relative paths in config should be '.' not ''

--- a/packages/myst-cli/src/config.ts
+++ b/packages/myst-cli/src/config.ts
@@ -106,7 +106,8 @@ function resolveToRelative(session: ISession, basePath: string, absPath: string)
   let message: string;
   try {
     if (fs.existsSync(absPath)) {
-      return relative(basePath, absPath);
+      // If it is the same path, use a '.'
+      return relative(basePath, absPath) || '.';
     }
     message = `Does not exist as local path: ${absPath}`;
   } catch {


### PR DESCRIPTION
This was causing errors in the site config when the project points to the same file, it was `''` rather than `'.'`