### PR TITLE
🔙 Bring back myst.min.js for unpackage

### DIFF
--- a/packages/mystjs/README.md
+++ b/packages/mystjs/README.md
@@ -117,7 +117,7 @@ The scripts for building, testing, and serving the project are in the [package.j
 
 ### `npm run build`
 
-Builds the library, including compiling the typescript and bundling/minification to create `index.umd.min.js` which can be used in the browser directly.
+Builds the library, including compiling the typescript and bundling/minification to create `myst.min.js` which can be used in the browser directly.
 Additionally, `index.cjs.js` is created which bundles ESM dependencies like `unified`, which can be helpful for tooling (e.g. `jest`) that can struggle with ESM modules.
 This outputs to the `dist` folder, and also includes all type definitions (`*.d.ts`) in the types folder.
 

--- a/packages/mystjs/index.html
+++ b/packages/mystjs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title>MyST Markdown Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
       body {
@@ -27,6 +27,7 @@
       }
     </style>
     <link rel="stylesheet" href="myst.css" />
+    <script type="text/javascript" src="dist/myst.min.js"></script>
   </head>
   <body onload="init();">
     <textarea id="input">
@@ -99,21 +100,21 @@ You can see in {eq}`line` that there is math!
     >
     <article id="output"></article>
     <script>
-      let input, output, examples, myst
-      const cache = {}
+      let input, output, examples, myst;
+      const cache = {};
       async function render() {
-        const html = await myst.render(input.value)
-        output.innerHTML = html
-        MathJax.typeset()
+        const html = await myst.render(input.value);
+        output.innerHTML = html;
+        MathJax.typeset();
       }
       function init() {
-        myst = new MyST()
-        input = document.getElementById('input')
-        output = document.getElementById('output')
-        examples = document.getElementById('examples')
-        input.onchange = render
-        input.onkeyup = render
-        render()
+        myst = new MyST();
+        input = document.getElementById('input');
+        output = document.getElementById('output');
+        examples = document.getElementById('examples');
+        input.onchange = render;
+        input.onkeyup = render;
+        render();
       }
       // Setup Mathjax
       MathJax = {
@@ -126,7 +127,7 @@ You can see in {eq}`line` that there is math!
         svg: {
           fontCache: 'global',
         },
-      }
+      };
     </script>
     <script
       type="text/javascript"

--- a/packages/mystjs/myst.ts
+++ b/packages/mystjs/myst.ts
@@ -1,0 +1,2 @@
+import { MyST } from './src/myst';
+globalThis.MyST = MyST;

--- a/packages/mystjs/package.json
+++ b/packages/mystjs/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "unpkg": "dist/index.umd.min.js",
+  "unpkg": "dist/myst.min.js",
   "types": "dist/types/index.d.ts",
   "files": [
     "dist"
@@ -34,7 +34,7 @@
     "lint": "eslint \"src/**/*.ts\" -c .eslintrc.js",
     "lint:format": "prettier --check src/*.ts src/**/*.ts",
     "build:bundle:cjs": "esbuild src/index.ts --bundle --outfile=dist/index.cjs.js --platform=node",
-    "build:bundle:browser": "esbuild src/index.ts --bundle --outfile=dist/index.umd.min.js --platform=browser --minify",
+    "build:bundle:browser": "esbuild myst.ts --bundle --outfile=dist/myst.min.js --platform=browser --minify",
     "build:esm": "tsc --module es2015   --outDir dist/esm",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs",
     "declarations": "tsc --declaration --emitDeclarationOnly --outDir dist/types",


### PR DESCRIPTION
This brings back the very simple mystjs demo:

![image](https://user-images.githubusercontent.com/913249/201539350-8ba09c69-96be-4b22-8e52-6f692c542484.png)


It was broken because we changed from rollup to esbuild, now that is back!