### PR TITLE
⏲ Await writeDocx during docx export

### DIFF
--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -193,7 +193,7 @@ export async function runWordExport(
   const docx = renderer(session, data, doc, options, jtex.templatePath, vfile);
   logMessagesFromVFile(session, vfile);
   session.log.info(`🖋  Writing docx to ${output}`);
-  writeDocx(docx, (buffer) => writeFileToFolder(output, buffer));
+  await writeDocx(docx, (buffer) => writeFileToFolder(output, buffer));
 }
 
 export async function localArticleToWord(


### PR DESCRIPTION
The final write to file during docx export was not awaited. Usually not a problem, since the file is written anyway, but it becomes a problem if the output is immediately consumed by another function (e.g. create output then read and upload to a server).