### PR TITLE
🌠 Add transform to CLI to convert svg/gif images to png on export

### DIFF
--- a/.changeset/wild-ants-dress.md
+++ b/.changeset/wild-ants-dress.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Bug fix: await docx export write to file

--- a/.changeset/young-coins-count.md
+++ b/.changeset/young-coins-count.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Transform svg/gif images to png if imagemagick or inkscape are available

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -130,6 +130,8 @@ function defaultWordRenderer(
     vfile,
     {
       getImageBuffer(image: string) {
+        // This extra read somehow prevents an error when buffer-image-size tries to get image dimensions...
+        fs.readFileSync(image);
         return Buffer.from(fs.readFileSync(image).buffer);
       },
       useFieldsForCrossReferences: false,

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -37,6 +37,7 @@ import {
   transformOutputs,
   transformCitations,
   transformImages,
+  transformImageFormats,
   transformThumbnail,
   StaticFileTransformer,
 } from '../transforms';
@@ -142,6 +143,10 @@ export async function transformMdast(
     .use(footnotesPlugin, { references }) // Needs to happen nead the end
     .run(mdast, vfile);
   await transformImages(session, mdast, file, imageWriteFolder, {
+    altOutputFolder: imageAltOutputFolder,
+  });
+  // Must happen after transformImages
+  await transformImageFormats(session, mdast, file, imageWriteFolder, {
     altOutputFolder: imageAltOutputFolder,
   });
   // Note, the thumbnail transform must be **after** images, as it may read the images

--- a/packages/myst-cli/src/utils/imagemagick.ts
+++ b/packages/myst-cli/src/utils/imagemagick.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import { sync as which } from 'which';
+import { makeExecutable } from 'myst-cli-utils';
+import type { ISession } from '../session/types';
+
+export function isImageMagickAvailable() {
+  return which('convert', { nothrow: true });
+}
+
+export async function extractFirstFrameOfGif(session: ISession, gif: string, writeFolder: string) {
+  if (!fs.existsSync(gif)) return null;
+  const { name, ext } = path.parse(gif);
+  if (ext !== '.gif') return null;
+  const pngFile = `${name}.png`;
+  const png = path.join(writeFolder, pngFile);
+  if (fs.existsSync(png)) {
+    session.log.debug(`Cached file found for extracted GIF: ${gif}`);
+  } else {
+    const convert = makeExecutable(`convert ${gif}[0] ${png}`, session.log);
+    try {
+      await convert();
+    } catch (err) {
+      session.log.error(`Could not extract an image from gif: ${gif} - ${err}`);
+      return null;
+    }
+  }
+  return pngFile;
+}
+
+export async function convertSVGToPNG(session: ISession, svg: string, writeFolder: string) {
+  if (!fs.existsSync(svg)) return null;
+  const { name, ext } = path.parse(svg);
+  if (ext !== '.svg') return null;
+  const pngFile = `${name}.png`;
+  const png = path.join(writeFolder, pngFile);
+  if (fs.existsSync(png)) {
+    session.log.debug(`Cached file found for converted SVG: ${svg}`);
+  } else {
+    const executable = `convert -density 600 ${svg} ${png}`;
+    session.log.debug(`Executing: ${executable}`);
+    const convert = makeExecutable(executable, session.log);
+    try {
+      await convert();
+    } catch (err) {
+      session.log.error(`Could not convert from SVG to PNG: ${svg} - ${err}`);
+      return null;
+    }
+  }
+  return pngFile;
+}

--- a/packages/myst-cli/src/utils/index.ts
+++ b/packages/myst-cli/src/utils/index.ts
@@ -15,3 +15,6 @@ export * from './resolveExtension';
 export * from './shouldIgnoreFile';
 export * from './toc';
 export * from './webFileObject';
+
+export * as imagemagick from './imagemagick';
+export * as inkscape from './inkscape';

--- a/packages/myst-cli/src/utils/inkscape.ts
+++ b/packages/myst-cli/src/utils/inkscape.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { sync as which } from 'which';
+import { makeExecutable } from 'myst-cli-utils';
+import type { ISession } from '../session/types';
+
+export function isInkscapeAvailable() {
+  return which('inkscape', { nothrow: true });
+}
+
+export async function convertSVGToPNG(session: ISession, svg: string, writeFolder: string) {
+  if (!fs.existsSync(svg)) return null;
+  const { name, ext } = path.parse(svg);
+  if (ext !== '.svg') return null;
+  const pngFile = `${name}.png`;
+  const png = path.join(writeFolder, pngFile);
+  if (fs.existsSync(png)) {
+    session.log.debug(`Cached file found for converted SVG: ${svg}`);
+  } else {
+    const convert = makeExecutable(
+      `inkscape ${svg} --export-area-drawing --export-type=png --export-filename=${png}`,
+      session.log,
+    );
+    try {
+      await convert();
+    } catch (err) {
+      session.log.error(`Could not convert from SVG to PNG: ${svg} - ${err}`);
+      return null;
+    }
+  }
+  return pngFile;
+}


### PR DESCRIPTION
SVGs and animated GIFs are not supported in PDF/Word exports. This adds a transform to convert these image types to PNG on export.

SVG transformation requires [imagemagick](https://imagemagick.org/index.php) or [inkscape](https://inkscape.org/) CLI; GIF transformation requires imagemagick. If these libraries are not available, source images will be unmodified.