### PR TITLE
🗃 Allow template.yml#files to be nested

### DIFF
--- a/.changeset/old-pants-nail.md
+++ b/.changeset/old-pants-nail.md
@@ -1,0 +1,5 @@
+---
+'jtex': patch
+---
+
+Allow nested files in template.yml

--- a/packages/jtex/docs/template-yml.md
+++ b/packages/jtex/docs/template-yml.md
@@ -200,7 +200,7 @@ condition
 
 ## Template Files
 
-The files are the flat list of files that are required by the template, the first entry should always be `template.tex`.
+The files are a list of unix-style paths to files that are required by the template. The first entry should always be `template.tex`; this must be in the top level folder next to the `template.yml`. All other files may be nested in sub-folders. This list may not include folders or wildcards.
 Common options to include are any `*.sty` files or images required by the template.
 
 ```yaml
@@ -209,7 +209,7 @@ files:
   - style.sty
   - citation.bst
   - custom.def
-  - logo.png
+  - images/logo.png
 ```
 
 These files, and only these files, will be copied in when using the template in `myst`.

--- a/packages/jtex/src/cli/check.ts
+++ b/packages/jtex/src/cli/check.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import yaml from 'js-yaml';
 import fs from 'fs';
-import { join, sep, extname } from 'path';
+import { join, extname, resolve } from 'path';
 import type { ISession } from '../types';
 import type { ValidationOptions } from 'simple-validators';
 import { PAGE_FRONTMATTER_KEYS } from 'myst-frontmatter';
@@ -294,19 +294,15 @@ export function checkTemplate(session: ISession, path: string, opts?: { fix?: bo
     });
     fixedFiles.push('template.tex', ...maybeExtraFiles);
   }
+  console.log(validated);
   const packageErrors =
     validated.files
       ?.map((file, i) => {
-        if (file.split(sep).length > 1) {
-          messages.errors.push({
-            property: `files.${i}`,
-            message: `The file "${file}" must be in the same directory as the main template.`,
-          });
-        }
+        const resolvedFile = resolve(templateDir, ...file.split('/'));
         let packages;
-        if (!fs.existsSync(file)) return true;
-        const fileContents = fs.readFileSync(join(templateDir, file)).toString();
-        switch (extname(file)) {
+        if (!fs.existsSync(resolvedFile)) return true;
+        const fileContents = fs.readFileSync(resolvedFile).toString();
+        switch (extname(resolvedFile)) {
           case '.cls':
           case '.tex':
           case '.def':

--- a/packages/jtex/src/cli/check.ts
+++ b/packages/jtex/src/cli/check.ts
@@ -294,7 +294,6 @@ export function checkTemplate(session: ISession, path: string, opts?: { fix?: bo
     });
     fixedFiles.push('template.tex', ...maybeExtraFiles);
   }
-  console.log(validated);
   const packageErrors =
     validated.files
       ?.map((file, i) => {

--- a/packages/jtex/src/validators.ts
+++ b/packages/jtex/src/validators.ts
@@ -475,6 +475,8 @@ export function validateTemplateYml(
         const filePath = path.resolve(opts.templateDir, ...file.split('/'));
         if (!fs.existsSync(filePath)) {
           validationError(`file does not exist: ${filePath}`, fileOpts);
+        } else if (fs.lstatSync(filePath).isDirectory()) {
+          validationError(`file must not be directory: ${filePath}`, fileOpts);
         }
       }
       return file;

--- a/packages/jtex/src/validators.ts
+++ b/packages/jtex/src/validators.ts
@@ -472,9 +472,9 @@ export function validateTemplateYml(
       const fileOpts = incrementOptions(`files.${ind}`, opts);
       const file = validateString(val, fileOpts);
       if (file && opts.templateDir) {
-        const filePath = path.join(opts.templateDir, file);
+        const filePath = path.resolve(opts.templateDir, ...file.split('/'));
         if (!fs.existsSync(filePath)) {
-          validationError(`file does not exist: ${path.join(opts.templateDir, file)}`, fileOpts);
+          validationError(`file does not exist: ${filePath}`, fileOpts);
         }
       }
       return file;

--- a/packages/jtex/tests/download.spec.ts
+++ b/packages/jtex/tests/download.spec.ts
@@ -11,7 +11,7 @@ describe('Download Template', () => {
     });
     expect(fs.existsSync('_build/templates/tex/myst/curvenote/template.zip')).toBe(true);
     expect(fs.existsSync('_build/templates/tex/myst/curvenote/template.yml')).toBe(true);
-    expect(fs.existsSync('_build/templates/tex/myst/curvenote/README.md')).toBe(true);
+    expect(fs.existsSync('_build/templates/tex/myst/curvenote/template.tex')).toBe(true);
   });
   it('Bad template paths to throw', async () => {
     const jtex = new JTex(new Session(), { template: 'not-there' });


### PR DESCRIPTION
Addresses #84 

Files defined in the `template.yml` may now be nested in arbitrary subfolders.

- `template.tex` must still be at the top level of the template directory
- Any other files may be defined with relative unix-style paths
- Folders and wildcard patters are still not allowed in `files`

Example:
```
jtex: v1
...
files:
  - template.tex
  - logos/logo.png
  - styles/myst.sty
```