### PR TITLE
🖇 Move isUrl utility to `myst-cli-utils`

### DIFF
--- a/.changeset/twelve-wombats-hear.md
+++ b/.changeset/twelve-wombats-hear.md
@@ -1,0 +1,7 @@
+---
+'intersphinx': patch
+'myst-cli': patch
+'myst-cli-utils': patch
+---
+
+Move isUrl utility to myst-cli-utils

--- a/packages/intersphinx/src/intersphinx.ts
+++ b/packages/intersphinx/src/intersphinx.ts
@@ -1,14 +1,8 @@
 import fs from 'fs';
 import zlib from 'zlib';
 import fetch from 'node-fetch';
+import { isUrl } from 'myst-cli-utils';
 import type { Domains } from './types';
-
-/**
- * Very simple function to test if the link starts with an HTTP(S?)
- */
-function isUrl(url: string): boolean {
-  return !!url.toLowerCase().match(/^https?:\/\//);
-}
 
 type Entry = { type: string; location: string; display?: string };
 type InventoryItem = { location: string; display?: string };

--- a/packages/myst-cli-utils/src/index.ts
+++ b/packages/myst-cli-utils/src/index.ts
@@ -9,5 +9,6 @@ export {
 } from './logger';
 export { exec, makeExecutable } from './exec';
 export { clirun, tic } from './utils';
+export { isUrl } from './isUrl';
 export { Session, getSession } from './session';
 export { writeFileToFolder } from './filesystem';

--- a/packages/myst-cli-utils/src/isUrl.ts
+++ b/packages/myst-cli-utils/src/isUrl.ts
@@ -1,0 +1,9 @@
+export function isUrl(url?: string): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol.includes('http');
+  } catch (error) {
+    return false;
+  }
+}

--- a/packages/myst-cli/src/process/citations.ts
+++ b/packages/myst-cli/src/process/citations.ts
@@ -2,11 +2,11 @@ import fs from 'fs';
 import fetch from 'node-fetch';
 import type { CitationRenderer } from 'citation-js-utils';
 import { getCitations } from 'citation-js-utils';
-import { tic } from 'myst-cli-utils';
+import { tic, isUrl } from 'myst-cli-utils';
 import type { ISession, ISessionWithCache } from '../session/types';
 import { castSession } from '../session';
 import { selectors } from '../store';
-import { addWarningForFile, isUrl } from '../utils';
+import { addWarningForFile } from '../utils';
 
 export async function loadCitations(session: ISession, path: string) {
   const toc = tic();

--- a/packages/myst-cli/src/process/intersphinx.ts
+++ b/packages/myst-cli/src/process/intersphinx.ts
@@ -1,9 +1,8 @@
 import { Inventory } from 'intersphinx';
-import { tic } from 'myst-cli-utils';
+import { tic, isUrl } from 'myst-cli-utils';
 import type { ISession } from '../session/types';
 import { castSession } from '../session';
 import { selectors } from '../store';
-import { isUrl } from '../utils';
 
 export async function loadIntersphinx(
   session: ISession,

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -1,12 +1,12 @@
-import chalk from 'chalk';
 import fs from 'fs';
 import { join } from 'path';
+import { isUrl } from 'myst-cli-utils';
 import { loadConfigAndValidateOrThrow } from '../config';
 import { loadFile, combineProjectCitationRenderers } from '../process';
 import type { ISession } from '../session/types';
 import { selectors } from '../store';
 import { projects } from '../store/reducers';
-import { getAllBibTexFilesOnPath, isDirectory, isUrl, validateTOC } from '../utils';
+import { getAllBibTexFilesOnPath, isDirectory, validateTOC } from '../utils';
 import { projectFromPath } from './fromPath';
 import { projectFromToc } from './fromToc';
 import { writeTocFromProject } from './toToc';

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import type { Root } from 'mdast';
 import mime from 'mime-types';
 import type { GenericNode } from 'myst-common';
+import { isUrl } from 'myst-cli-utils';
 import { selectAll } from 'unist-util-select';
 import fetch from 'node-fetch';
 import path from 'path';
@@ -13,7 +14,6 @@ import {
   hashAndCopyStaticFile,
   imagemagick,
   inkscape,
-  isUrl,
 } from '../utils';
 import type { ISession } from '../session/types';
 import chalk from 'chalk';

--- a/packages/myst-cli/src/utils/index.ts
+++ b/packages/myst-cli/src/utils/index.ts
@@ -7,7 +7,6 @@ export * from './filterFilenamesByExtension';
 export * from './getAllBibtexFiles';
 export * from './hashAndCopyStaticFile';
 export * from './isDirectory';
-export * from './isUrl';
 export * from './logMessagesFromVFile';
 export * from './nextLevel';
 export * from './removeExtension';

--- a/packages/myst-cli/src/utils/isUrl.ts
+++ b/packages/myst-cli/src/utils/isUrl.ts
@@ -1,3 +1,0 @@
-export function isUrl(url: string): boolean {
-  return !!url.toLowerCase().match(/^https?:\/\//);
-}


### PR DESCRIPTION
Centralize, improve and re-use this utility.