### PR TITLE
🆙 Upgrade doi-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3960,8 +3960,9 @@
       }
     },
     "node_modules/doi-utils": {
-      "version": "1.0.4",
-      "license": "MIT"
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-1.0.6.tgz",
+      "integrity": "sha512-p3bPw3T+tUa1Cs0WzBA4o3kmYqifiU/9w2ZKK8UNXjcX5AOfmxbaWqHO3k97PzI9BxAvIaIJcw10U62GHzmpVw=="
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -11410,7 +11411,7 @@
         "commander": "^9.4.1",
         "crypto": "^1.0.1",
         "docx": "^7.5.0",
-        "doi-utils": "^1.0.4",
+        "doi-utils": "^1.0.6",
         "inquirer": "^8.2.2",
         "intersphinx": "^0.0.4",
         "js-yaml": "^4.1.0",
@@ -11636,7 +11637,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "doi-utils": "^1.0.4",
+        "doi-utils": "^1.0.6",
         "simple-validators": "^0.0.2"
       },
       "devDependencies": {
@@ -11756,7 +11757,7 @@
       "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
-        "doi-utils": "^1.0.4",
+        "doi-utils": "^1.0.6",
         "intersphinx": "*",
         "js-yaml": "^4.1.0",
         "katex": "^0.15.2",
@@ -14573,7 +14574,9 @@
       }
     },
     "doi-utils": {
-      "version": "1.0.4"
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-1.0.6.tgz",
+      "integrity": "sha512-p3bPw3T+tUa1Cs0WzBA4o3kmYqifiU/9w2ZKK8UNXjcX5AOfmxbaWqHO3k97PzI9BxAvIaIJcw10U62GHzmpVw=="
     },
     "dom-serializer": {
       "version": "1.4.1",
@@ -17088,7 +17091,7 @@
         "concurrently": "^7.5.0",
         "crypto": "^1.0.1",
         "docx": "^7.5.0",
-        "doi-utils": "^1.0.4",
+        "doi-utils": "^1.0.6",
         "esbuild": "^0.15.12",
         "eslint": "^8.21.0",
         "eslint-config-curvenote": "*",
@@ -17256,7 +17259,7 @@
       "version": "file:packages/myst-frontmatter",
       "requires": {
         "@types/jest": "^28.1.6",
-        "doi-utils": "^1.0.4",
+        "doi-utils": "^1.0.6",
         "eslint": "^8.21.0",
         "eslint-config-curvenote": "*",
         "jest": "28.1.3",
@@ -17362,7 +17365,7 @@
       "version": "file:packages/myst-transforms",
       "requires": {
         "@types/katex": "^0.14.0",
-        "doi-utils": "^1.0.4",
+        "doi-utils": "^1.0.6",
         "eslint": "^8.21.0",
         "eslint-config-curvenote": "*",
         "intersphinx": "*",

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -62,7 +62,7 @@
     "commander": "^9.4.1",
     "crypto": "^1.0.1",
     "docx": "^7.5.0",
-    "doi-utils": "^1.0.4",
+    "doi-utils": "^1.0.6",
     "inquirer": "^8.2.2",
     "intersphinx": "^0.0.4",
     "js-yaml": "^4.1.0",

--- a/packages/myst-frontmatter/package.json
+++ b/packages/myst-frontmatter/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/executablebooks/mystjs/issues"
   },
   "dependencies": {
-    "doi-utils": "^1.0.4",
+    "doi-utils": "^1.0.6",
     "simple-validators": "^0.0.2"
   },
   "devDependencies": {

--- a/packages/myst-transforms/package.json
+++ b/packages/myst-transforms/package.json
@@ -26,7 +26,7 @@
     "build": "npm-run-all -l clean -p build:cjs build:esm declarations"
   },
   "dependencies": {
-    "doi-utils": "^1.0.4",
+    "doi-utils": "^1.0.6",
     "intersphinx": "*",
     "js-yaml": "^4.1.0",
     "katex": "^0.15.2",


### PR DESCRIPTION
This improves doi-lookups from a number of sources, and changes the `validate` logic slightly to be more sensible.

Diff:
https://github.com/curvenote/doi-utils/compare/v1.0.4...v1.0.6