### PR TITLE
📒 Support basic callouts that use `*.qmd` syntax

### DIFF
--- a/.changeset/giant-gifts-raise.md
+++ b/.changeset/giant-gifts-raise.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Support basic callout admonitions that use the QMD format (e.g. `{.callout-tip}`). More to come in the future!

--- a/packages/myst-cli/src/process/myst/directives.ts
+++ b/packages/myst-cli/src/process/myst/directives.ts
@@ -783,6 +783,14 @@ const Header: IDirective = {
   hast: (h, node) => h(node, 'header'),
 };
 
+function aliasDirectiveHack(directive: IDirective['myst']): IDirective {
+  return {
+    myst: directive,
+    mdast: { type: '_' },
+    hast: (h, node) => h(node, '_'),
+  };
+}
+
 export const directives = {
   image: Image,
   'r:var': RVar,
@@ -808,4 +816,9 @@ export const directives = {
   header: Header,
   grid: Grid,
   'grid-item-card': Card,
+  '.callout-note': aliasDirectiveHack(directivesDefault.note),
+  '.callout-warning': aliasDirectiveHack(directivesDefault.warning),
+  '.callout-important': aliasDirectiveHack(directivesDefault.important),
+  '.callout-tip': aliasDirectiveHack(directivesDefault.tip),
+  '.callout-caution': aliasDirectiveHack(directivesDefault.caution),
 };


### PR DESCRIPTION
This is currently a hack in the directives folder, which needs a lot of love, but adds some basic compatibility for working with Quarto documents.