### PR TITLE
🗂 Document tab behaviour

### DIFF
--- a/.changeset/angry-maps-clean.md
+++ b/.changeset/angry-maps-clean.md
@@ -1,0 +1,5 @@
+---
+'myst-spec-ext': patch
+---
+
+Add tabs to myst-spec-ext

--- a/docs/dropdowns-cards-and-tabs.md
+++ b/docs/dropdowns-cards-and-tabs.md
@@ -109,9 +109,11 @@ You can also produce tabbed content. This allows you to display a variety of tab
 `````markdown
 ````{tab-set}
 ```{tab-item} Tab 1
+:sync: tab1
 Tab one
 ```
 ```{tab-item} Tab 2
+:sync: tab2
 Tab two
 ```
 ````
@@ -121,11 +123,11 @@ Creates:
 
 ````{tab-set}
 ```{tab-item} Tab 1
-:sync: t1
+:sync: tab1
 Tab one
 ```
 ```{tab-item} Tab 2
-:sync: t2
+:sync: tab2
 Tab two
 ```
 ````
@@ -134,11 +136,32 @@ If you have multiple tabs with the same name, they will be synced!
 
 ````{tab-set}
 ```{tab-item} Tab 1
-:sync: t1
+:sync: tab1
 Synced content for tab 1
 ```
 ```{tab-item} Tab 2
-:sync: t2
+:sync: tab2
 Synced content for tab 2
 ```
 ````
+
+### `tab-item` reference
+
+**Arguments** _(required: `1`, string)_
+: The `tab-item` requires a single argument that is the title as a string.
+
+    ```{warning}
+    :class: dropdown
+    # Note: the `tab-item` title is not currently not parsed
+
+    The current implementation does not parse the tab title properly, and markup in this field will not be parsed.
+    ```
+
+**Options**
+: No options for the `tab-item` are required
+
+    sync _(optional, string)_
+    : A key that is used to sync the selected tab across multiple tab-sets.
+
+    selected _(flag, no-value)_
+    : a flag indicating whether the tab should be selected by default.

--- a/packages/myst-cli/src/process/myst/directives.ts
+++ b/packages/myst-cli/src/process/myst/directives.ts
@@ -378,6 +378,47 @@ const TabSet: IDirective = {
   hast: (h, node) => h(node, 'div', { class: 'margin' }),
 };
 
+const TabItem: IDirective = {
+  myst: class TabItem extends Directive {
+    public required_arguments = 1;
+
+    public optional_arguments = 0;
+
+    public final_argument_whitespace = true;
+
+    public has_content = true;
+
+    public option_spec = {
+      sync: directiveOptions.unchanged,
+      selected: directiveOptions.flag,
+    };
+
+    run(data: IDirectiveData<keyof TabItem['option_spec']>) {
+      const newTokens: Token[] = [];
+      const adToken = this.createToken('tabItem_open', 'div', 1, {
+        map: data.map,
+        block: true,
+        meta: { title: data.args[0] },
+      });
+      newTokens.push(adToken);
+      const bodyTokens = this.nestedParse(data.body, data.bodyMap[0]);
+      newTokens.push(...bodyTokens);
+      newTokens.push(this.createToken('tabItem_close', 'div', -1, { block: true }));
+      return newTokens;
+    }
+  },
+  mdast: {
+    type: 'tabItem',
+    getAttrs(t) {
+      return {
+        title: t.meta.title,
+        sync: t.meta.sync,
+      };
+    },
+  },
+  hast: (h, node) => h(node, 'div', { class: 'margin' }),
+};
+
 function getColumns(columnString: string, defaultColumns = [1, 2, 2, 3]) {
   const columns = (columnString ?? '1 2 2 3')
     .split(/\s/)
@@ -435,46 +476,6 @@ const Grid: IDirective = {
     },
   },
   hast: (h, node) => h(node, 'div'),
-};
-
-const TabItem: IDirective = {
-  myst: class TabItem extends Directive {
-    public required_arguments = 1;
-
-    public optional_arguments = 0;
-
-    public final_argument_whitespace = true;
-
-    public has_content = true;
-
-    public option_spec = {
-      sync: directiveOptions.unchanged,
-    };
-
-    run(data: IDirectiveData<keyof TabItem['option_spec']>) {
-      const newTokens: Token[] = [];
-      const adToken = this.createToken('tabItem_open', 'div', 1, {
-        map: data.map,
-        block: true,
-        meta: { title: data.args[0] },
-      });
-      newTokens.push(adToken);
-      const bodyTokens = this.nestedParse(data.body, data.bodyMap[0]);
-      newTokens.push(...bodyTokens);
-      newTokens.push(this.createToken('tabItem_close', 'div', -1, { block: true }));
-      return newTokens;
-    }
-  },
-  mdast: {
-    type: 'tabItem',
-    getAttrs(t) {
-      return {
-        title: t.meta.title,
-        sync: t.meta.sync,
-      };
-    },
-  },
-  hast: (h, node) => h(node, 'div', { class: 'margin' }),
 };
 
 const MystDemo: IDirective = {

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -34,3 +34,14 @@ export type FootnoteReference = FNR & {
 };
 
 export type TableCell = SpecTableCell & { colspan?: number; rowspan?: number; width?: number };
+
+export type TabSet = Parent & {
+  type: 'tabSet';
+};
+
+export type TabItem = Parent & {
+  type: 'tabItem';
+  title: string;
+  sync?: string;
+  selected?: boolean;
+};


### PR DESCRIPTION
This is tracking some improvements made to tabs and adds the `selected` property to allow you to open a tag to a certain area. The UI is shown here:
https://curvenote.github.io/theme-base/?path=/story/components-tabs--semi-synced-tabs

I have also moved the `spec-ext` type definition to the appropriate place for now.