### PR TITLE
☢️ Improve warning formatting

### DIFF
--- a/.changeset/cold-yaks-fail.md
+++ b/.changeset/cold-yaks-fail.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Improve warning formatting and information capture for errors

--- a/packages/myst-cli/src/store/types.ts
+++ b/packages/myst-cli/src/store/types.ts
@@ -1,3 +1,5 @@
+import type { VFileMessage } from 'vfile-message';
+
 export type ExternalLinkResult = {
   url: string;
   ok?: boolean;
@@ -11,4 +13,7 @@ export type WarningKind = 'error' | 'warn' | 'info';
 export type BuildWarning = {
   message: string;
   kind: WarningKind;
+  note?: string | null;
+  url?: string | null;
+  position?: VFileMessage['position'];
 };

--- a/packages/myst-cli/src/utils/addWarningForFile.ts
+++ b/packages/myst-cli/src/utils/addWarningForFile.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type { VFileMessage } from 'vfile-message';
 import type { ISession } from '../session/types';
 import { warnings } from '../store/reducers';
@@ -8,27 +9,40 @@ export function addWarningForFile(
   file: string | undefined | null,
   message: string,
   kind: WarningKind = 'warn',
-  opts?: { note?: string; position?: VFileMessage['position'] },
+  opts?: { note?: string | null; url?: string | null; position?: VFileMessage['position'] },
 ) {
   const specific = opts?.position?.start.line
     ? `:${opts?.position.start.line}${
         opts?.position.start.column ? `:${opts?.position.start.column}` : ''
       }`
     : '';
+
+  const note = opts?.note ? `\n   ${chalk.reset.dim(opts.note)}` : '';
+  const url = opts?.url ? chalk.reset.dim(`\n   See also: ${opts.url}\n`) : '';
   const prefix = file ? `${file}${specific} ` : '';
+  const formatted = `${message}${note}${url}`;
   switch (kind) {
     case 'info':
-      session.log.info(`ℹ️ ${prefix}${message}`);
+      session.log.info(`ℹ️ ${prefix}${formatted}`);
       break;
     case 'error':
-      session.log.error(`⛔️ ${prefix}${message}`);
+      session.log.error(`⛔️ ${prefix}${formatted}`);
       break;
     case 'warn':
     default:
-      session.log.warn(`⚠️  ${prefix}${message}`);
+      session.log.warn(`⚠️  ${prefix}${formatted}`);
       break;
   }
   if (file) {
-    session.store.dispatch(warnings.actions.addWarning({ file, message, kind }));
+    session.store.dispatch(
+      warnings.actions.addWarning({
+        file,
+        message,
+        kind,
+        url: opts?.url,
+        note: opts?.note,
+        position: opts?.position,
+      }),
+    );
   }
 }

--- a/packages/myst-cli/src/utils/logMessagesFromVFile.ts
+++ b/packages/myst-cli/src/utils/logMessagesFromVFile.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import type { VFile } from 'vfile';
 import type { ISession } from '../session/types';
 import type { WarningKind } from '../store/types';
@@ -9,10 +8,10 @@ export function logMessagesFromVFile(session: ISession, file?: VFile): void {
   file.messages.forEach((message) => {
     const kind: WarningKind =
       message.fatal === null ? 'info' : message.fatal === false ? 'warn' : 'error';
-    const note = message.note ? `\n\n${chalk.dim(message.note)}` : '';
-    const url = message.url ? chalk.dim(`\n\nSee also: ${message.url}\n`) : '';
-    addWarningForFile(session, file.path, `${message.message}${note}${url}`, kind, {
+    addWarningForFile(session, file.path, message.message, kind, {
       position: message.position,
+      note: message.note,
+      url: message.url,
     });
   });
   file.messages = [];


### PR DESCRIPTION
This improves the format and error capture (e.g. node position).

![image](https://user-images.githubusercontent.com/913249/213005951-f0678b0a-b540-4653-be18-bfbe026dde00.png)

Previously the entire message was red, this dims and indents the "note" and "see also" information for a log message.