### PR TITLE
🛏 Embed notebook cells in a page

### DIFF
--- a/.changeset/forty-pillows-retire.md
+++ b/.changeset/forty-pillows-retire.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Update figure/image nodes to embed images if given a target instead of a file path / url

--- a/.changeset/ninety-ducks-reflect.md
+++ b/.changeset/ninety-ducks-reflect.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'myst-transforms': patch
+---
+
+Embed block content (including notebook cells) based on block or code cell label in metadata

--- a/.changeset/young-spies-hunt.md
+++ b/.changeset/young-spies-hunt.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix inline DOIs to update references in tex/pdf export

--- a/package-lock.json
+++ b/package-lock.json
@@ -11740,6 +11740,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-filter": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-4.0.0.tgz",
+      "integrity": "sha512-H4iTOv2p+n83xjhx7eGFA3zSx7Xcv3Iv9lNQRpXiR8dmm9LtslhyjVlQrZLbkk4jwUrJgc8PPGkOOrfhb76s4Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      }
+    },
     "node_modules/unist-util-find-after": {
       "version": "4.0.0",
       "license": "MIT",
@@ -12570,6 +12580,7 @@
         "simple-validators": "^0.0.3",
         "tex-to-myst": "^0.0.11",
         "unified": "^10.1.2",
+        "unist-util-filter": "^4.0.0",
         "unist-util-remove": "^3.1.0",
         "vfile": "^5.3.5",
         "which": "^2.0.2",
@@ -19100,6 +19111,7 @@
         "ts-jest": "^28.0.7",
         "typescript": "latest",
         "unified": "^10.1.2",
+        "unist-util-filter": "^4.0.0",
         "unist-util-remove": "^3.1.0",
         "vfile": "^5.3.5",
         "which": "^2.0.2",
@@ -21417,6 +21429,16 @@
       "version": "3.0.0",
       "requires": {
         "@types/unist": "^2.0.0"
+      }
+    },
+    "unist-util-filter": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-4.0.0.tgz",
+      "integrity": "sha512-H4iTOv2p+n83xjhx7eGFA3zSx7Xcv3Iv9lNQRpXiR8dmm9LtslhyjVlQrZLbkk4jwUrJgc8PPGkOOrfhb76s4Q==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
       }
     },
     "unist-util-find-after": {

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -88,6 +88,7 @@
     "simple-validators": "^0.0.3",
     "tex-to-myst": "^0.0.11",
     "unified": "^10.1.2",
+    "unist-util-filter": "^4.0.0",
     "unist-util-remove": "^3.1.0",
     "vfile": "^5.3.5",
     "which": "^2.0.2",

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -34,6 +34,7 @@ import {
   checkLinksTransform,
   importMdastFromJson,
   includeFilesDirective,
+  liftCodeMetadataToBlock,
   transformLinkedDOIs,
   transformOutputs,
   transformCitations,
@@ -116,6 +117,8 @@ export async function transformMdast(
   // Import additional content from mdast or other files
   importMdastFromJson(session, file, mdast);
   includeFilesDirective(session, file, mdast);
+  // This needs to come before basic transformations since it may add labels to blocks
+  liftCodeMetadataToBlock(session, file, mdast);
 
   await unified()
     .use(basicTransformationsPlugin)

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -32,6 +32,7 @@ import type { RendererData } from '../transforms/types';
 import { KINDS } from '../transforms/types';
 import {
   checkLinksTransform,
+  embedDirective,
   importMdastFromJson,
   includeFilesDirective,
   liftCodeMetadataToBlock,
@@ -234,6 +235,7 @@ export async function postProcessMdast(
     selector: LINKS_SELECTOR,
   });
   resolveReferencesTransform(mdastPost.mdast, state.file as VFile, { state });
+  embedDirective(mdastPost.mdast, state);
   // Ensure there are keys on every node
   keysTransform(mdastPost.mdast);
   logMessagesFromVFile(session, fileState.file);

--- a/packages/myst-cli/src/process/myst/directives.ts
+++ b/packages/myst-cli/src/process/myst/directives.ts
@@ -754,7 +754,6 @@ const EmbedOutput: IDirective = {
     };
 
     run(data: IDirectiveData<keyof EmbedOutput['option_spec']>) {
-      console.log(data);
       const token = this.createToken('embed', 'div', 0, {
         content: data.body,
         map: data.bodyMap,

--- a/packages/myst-cli/src/process/myst/directives.ts
+++ b/packages/myst-cli/src/process/myst/directives.ts
@@ -736,6 +736,55 @@ const Card: IDirective = {
   hast: (h, node) => h(node, 'details'),
 };
 
+const EmbedOutput: IDirective = {
+  myst: class EmbedOutput extends Directive {
+    public required_arguments = 0;
+
+    public optional_arguments = 0;
+
+    public final_argument_whitespace = false;
+
+    public has_content = false;
+
+    public option_spec = {
+      label: directiveOptions.unchanged,
+      caption: directiveOptions.unchanged,
+      'remove-input': directiveOptions.flag,
+      'remove-output': directiveOptions.flag,
+    };
+
+    run(data: IDirectiveData<keyof EmbedOutput['option_spec']>) {
+      console.log(data);
+      const token = this.createToken('embed', 'div', 0, {
+        content: data.body,
+        map: data.bodyMap,
+        block: true,
+        meta: {
+          label: data.options.label,
+          caption: data.options.caption,
+          'remove-input': data.options['remove-input'] === null,
+          'remove-output': data.options['remove-output'] === null,
+        },
+      });
+      return [token];
+    }
+  },
+  mdast: {
+    type: 'embed',
+    noCloseToken: true,
+    isLeaf: true,
+    getAttrs(t) {
+      return {
+        label: t.meta.label,
+        caption: t.meta.caption,
+        'remove-input': t.meta['remove-input'],
+        'remove-output': t.meta['remove-output'],
+      };
+    },
+  },
+  hast: (h, node) => h(node, 'div'),
+};
+
 // The extension is forcing us to add this as a full thing, we are just putting `false` in "myst".
 const Summary: IDirective = {
   myst: false as any,
@@ -817,6 +866,7 @@ export const directives = {
   header: Header,
   grid: Grid,
   'grid-item-card': Card,
+  embed: EmbedOutput,
   '.callout-note': aliasDirectiveHack(directivesDefault.note),
   '.callout-warning': aliasDirectiveHack(directivesDefault.warning),
   '.callout-important': aliasDirectiveHack(directivesDefault.important),

--- a/packages/myst-cli/src/process/myst/directives.ts
+++ b/packages/myst-cli/src/process/myst/directives.ts
@@ -748,7 +748,6 @@ const EmbedOutput: IDirective = {
 
     public option_spec = {
       label: directiveOptions.unchanged,
-      caption: directiveOptions.unchanged,
       'remove-input': directiveOptions.flag,
       'remove-output': directiveOptions.flag,
     };
@@ -760,7 +759,6 @@ const EmbedOutput: IDirective = {
         block: true,
         meta: {
           label: data.options.label,
-          caption: data.options.caption,
           'remove-input': data.options['remove-input'] === null,
           'remove-output': data.options['remove-output'] === null,
         },
@@ -775,7 +773,6 @@ const EmbedOutput: IDirective = {
     getAttrs(t) {
       return {
         label: t.meta.label,
-        caption: t.meta.caption,
         'remove-input': t.meta['remove-input'],
         'remove-output': t.meta['remove-output'],
       };

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -44,10 +44,13 @@ export async function processNotebook(
     end = -1;
   }
 
-  const items = await cells?.slice(0, end).reduce(async (P, cell: ICell) => {
+  const items = await cells?.slice(0, end).reduce(async (P, cell: ICell, index) => {
     const acc = await P;
     if (cell.cell_type === CELL_TYPES.markdown) {
-      return acc.concat(`${blockDivider(cell)}${asString(cell.source)}`);
+      const cellContent = asString(cell.source);
+      // If the first cell is a frontmatter block, do not put a block break above it
+      const omitBlockDivider = index === 0 && cellContent.startsWith('---\n');
+      return acc.concat(`${omitBlockDivider ? '' : blockDivider(cell)}${cellContent}`);
     }
     if (cell.cell_type === CELL_TYPES.raw) {
       return acc.concat(`${blockDivider(cell)}\`\`\`\n${asString(cell.source)}\n\`\`\``);

--- a/packages/myst-cli/src/transforms/code.spec.ts
+++ b/packages/myst-cli/src/transforms/code.spec.ts
@@ -1,0 +1,116 @@
+import { Session } from '../session';
+import { liftCodeMetadataToBlock, metadataFromCode } from './code';
+
+describe('metadataFromCode', () => {
+  it('empty code returns self', async () => {
+    const value = '';
+    expect(metadataFromCode(new Session(), '', value)).toEqual({ value });
+  });
+  it('normal code returns self', async () => {
+    const value = 'a = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value)).toEqual({ value });
+  });
+  it('starting newlines are persisted without metadata', async () => {
+    const value = '\n\n\na = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value)).toEqual({ value });
+  });
+  it('starting comments are persisted', async () => {
+    const value = '\n# comment\n\na = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value)).toEqual({ value });
+  });
+  it('basic metadata is parsed', async () => {
+    const value = '#| key: value\n#| flag: true\n\na = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value)).toEqual({
+      value,
+      metadata: { key: 'value', flag: true },
+    });
+  });
+  it('whitespace is ignored around metadata', async () => {
+    const value = '\n\n#| key: value\n\n#| flag: true\n\n\na = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value)).toEqual({
+      value,
+      metadata: { key: 'value', flag: true },
+    });
+  });
+  it('whitespace is removed around metadata', async () => {
+    const value = '\n\n#| key: value\n\n#| flag: true\n\n\na = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value, { remove: true })).toEqual({
+      value: 'a = 5 + 5\nprint(a)',
+      metadata: { key: 'value', flag: true },
+    });
+  });
+  it('invalid metadata is passed and not removed', async () => {
+    const value = '\n\n#| invalid\n\n#|   yaml...:\n\n\na = 5 + 5\nprint(a)';
+    expect(metadataFromCode(new Session(), '', value, { remove: true })).toEqual({
+      value,
+    });
+  });
+});
+
+describe('liftCodeMetadataToBlock', () => {
+  it('no code metadata', async () => {
+    const mdast: any = {
+      type: 'root',
+      children: [
+        {
+          type: 'block',
+          data: { key: 'value' },
+          children: [
+            {
+              type: 'code',
+              value: 'print("hello world")',
+            },
+          ],
+        },
+      ],
+    };
+    liftCodeMetadataToBlock(new Session(), '', mdast);
+    expect(mdast.children[0].data).toEqual({ key: 'value' });
+    expect(mdast.children[0].children[0].value).toEqual('print("hello world")');
+  });
+  it('metadata moved to block data', async () => {
+    const mdast: any = {
+      type: 'root',
+      children: [
+        {
+          type: 'block',
+          data: { key: 'value' },
+          children: [
+            {
+              type: 'code',
+              value: '#| label: codeBlock\nprint("hello world")',
+            },
+          ],
+        },
+      ],
+    };
+    liftCodeMetadataToBlock(new Session(), '', mdast);
+    expect(mdast.children[0].data).toEqual({ key: 'value', label: 'codeBlock' });
+    expect(mdast.children[0].children[0].value).toEqual('print("hello world")');
+  });
+  it('multiple metadata, first moved to block, other ignored', async () => {
+    const mdast: any = {
+      type: 'root',
+      children: [
+        {
+          type: 'block',
+          data: { key: 'value' },
+          children: [
+            {
+              type: 'code',
+              value: '#| label: codeBlock\nprint("hello world")',
+            },
+            {
+              type: 'code',
+              value: '#| label: another\nprint("hello world2")',
+            },
+          ],
+        },
+      ],
+    };
+    liftCodeMetadataToBlock(new Session(), '', mdast);
+    expect(mdast.children[0].data).toEqual({ key: 'value', label: 'codeBlock' });
+    expect(mdast.children[0].children[0].value).toEqual('print("hello world")');
+    expect(mdast.children[0].children[1].value).toEqual('print("hello world2")');
+  });
+});

--- a/packages/myst-cli/src/transforms/code.ts
+++ b/packages/myst-cli/src/transforms/code.ts
@@ -1,0 +1,85 @@
+import type { GenericNode } from 'mystjs';
+import type { Root } from 'mdast';
+import { selectAll } from 'unist-util-select';
+import yaml from 'js-yaml';
+import type { ISession } from '../session/types';
+
+const CELL_OPTION_PREFIX = '#| ';
+
+/**
+ * Parse metadata from code block using js-yaml
+ *
+ * Metadata is defined at the begining of code cells as:
+ *
+ * ```python
+ * #| key: value
+ * #| flag: true
+ *
+ * print('hello world')
+ * ```
+ *
+ * New lines around metadata will be ignored, but once a non-metadata line
+ * is encountered, metadata parsing is stopped (i.e. you cannot define
+ * metadata in the middle of other code).
+ */
+export function metadataFromCode(
+  session: ISession,
+  filename: string,
+  value: string,
+  opts?: { remove?: boolean },
+): { value: string; metadata?: Record<string, any> } {
+  const metaLines: string[] = [];
+  const outputLines: string[] = [];
+  let inHeader = true;
+  value.split('\n').forEach((line) => {
+    if (inHeader) {
+      if (line.startsWith(CELL_OPTION_PREFIX)) {
+        metaLines.push(line.substring(CELL_OPTION_PREFIX.length));
+      } else if (line.trim()) {
+        inHeader = false;
+      }
+    }
+    if (!inHeader || !opts?.remove) {
+      outputLines.push(line);
+    }
+  });
+  let metadata: Record<string, any> | undefined;
+  if (metaLines.length) {
+    try {
+      metadata = yaml.load(metaLines.join('\n')) as Record<string, any>;
+    } catch {
+      session.log.error(`Invalid code cell metadata in ${filename}`);
+    }
+  }
+  if (!metadata) {
+    return { value };
+  }
+  return {
+    value: outputLines.join('\n'),
+    metadata,
+  };
+}
+
+/**
+ * Traverse mdast, remove code cell metadata, and add it to parent block
+ */
+export function liftCodeMetadataToBlock(session: ISession, filename: string, mdast: Root) {
+  const blocks = selectAll('block', mdast) as GenericNode[];
+  blocks.forEach((block) => {
+    const codeNodes = selectAll('code', block) as GenericNode[];
+    let blockMetadata: Record<string, any> | undefined;
+    codeNodes.forEach((node) => {
+      if (!node.value) return;
+      const { metadata, value } = metadataFromCode(session, filename, node.value, { remove: true });
+      if (blockMetadata && metadata) {
+        session.log.warn(`Multiple code blocks with metadata found in ${filename}`);
+      } else {
+        blockMetadata = metadata;
+      }
+      node.value = value;
+    });
+    if (blockMetadata) {
+      block.data = block.data ? { ...block.data, ...blockMetadata } : blockMetadata;
+    }
+  });
+}

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -3,7 +3,7 @@ import type { Root } from 'mdast';
 import { filter } from 'unist-util-filter';
 import { selectAll } from 'unist-util-select';
 import type { IReferenceState } from 'myst-transforms';
-import { normalizeLabel } from 'myst-common';
+import { copyNode, normalizeLabel } from 'myst-common';
 
 /**
  * This is the {embed} directive, that embeds nodes from elsewhere in a page.
@@ -15,13 +15,13 @@ export function embedDirective(mdast: Root, state: IReferenceState) {
     if (!normalized) return;
     const target = state.getTarget(normalized.identifier);
     if (!target) return;
-    let newNode = target.node as any;
+    let newNode = copyNode(target.node as any);
     if (node['remove-output']) {
       newNode = filter(newNode, (n: GenericNode) => n.type !== 'output');
     }
     if (node['remove-input']) {
       newNode = filter(newNode, (n: GenericNode) => n.type !== 'code');
     }
-    node.children = [newNode];
+    node.children = newNode ? [newNode] : [];
   });
 }

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -1,0 +1,27 @@
+import type { GenericNode } from 'mystjs';
+import type { Root } from 'mdast';
+import { filter } from 'unist-util-filter';
+import { selectAll } from 'unist-util-select';
+import type { IReferenceState } from 'myst-transforms';
+import { normalizeLabel } from 'myst-common';
+
+/**
+ * This is the {embed} directive, that embeds nodes from elsewhere in a page.
+ */
+export function embedDirective(mdast: Root, state: IReferenceState) {
+  const embedNodes = selectAll('embed', mdast) as GenericNode[];
+  embedNodes.forEach((node) => {
+    const normalized = normalizeLabel(node.label);
+    if (!normalized) return;
+    const target = state.getTarget(normalized.identifier);
+    if (!target) return;
+    let newNode = target.node as any;
+    if (node['remove-output']) {
+      newNode = filter(newNode, (n: GenericNode) => n.type !== 'output');
+    }
+    if (node['remove-input']) {
+      newNode = filter(newNode, (n: GenericNode) => n.type !== 'code');
+    }
+    node.children = [newNode];
+  });
+}

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -166,6 +166,14 @@ export async function transformImages(
   const images = selectAll('image', mdast) as GenericNode[];
   return Promise.all(
     images.map(async (image) => {
+      // If image URL starts with #, replace this node with embed node
+      if (image.url.startsWith('#')) {
+        image.type = 'embed';
+        image.label = image.url.substring(1);
+        image['remove-input'] = true;
+        delete image.url;
+        return;
+      }
       // Look up the image paths by known extensions if it is not provided
       const imagePath = path.join(path.dirname(file), image.url);
       if (!fs.existsSync(imagePath)) {

--- a/packages/myst-cli/src/transforms/index.ts
+++ b/packages/myst-cli/src/transforms/index.ts
@@ -1,4 +1,5 @@
 export * from './citations';
+export * from './code';
 export * from './dois';
 export * from './images';
 export * from './include';

--- a/packages/myst-cli/src/transforms/index.ts
+++ b/packages/myst-cli/src/transforms/index.ts
@@ -1,6 +1,7 @@
 export * from './citations';
 export * from './code';
 export * from './dois';
+export * from './embed';
 export * from './images';
 export * from './include';
 export * from './links';

--- a/packages/myst-transforms/src/basic.ts
+++ b/packages/myst-transforms/src/basic.ts
@@ -27,9 +27,10 @@ export function basicTransformations(tree: Root, file: VFile) {
   // Label headings after the targets-transform
   headingLabelTransform(tree);
   admonitionHeadersTransform(tree);
-  htmlIdsTransform(tree);
   blockNestingTransform(tree);
+  // Block metadata may contain labels/html_ids
   blockMetadataTransform(tree, file);
+  htmlIdsTransform(tree);
   imageAltTextTransform(tree);
   blockquoteTransform(tree);
 }

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -268,7 +268,7 @@ export class ReferenceState implements IReferenceState {
     }
     if (node.identifier) {
       this.targets[node.identifier] = {
-        node: copyNode(node),
+        node,
         kind: kind as TargetKind,
       };
     }

--- a/packages/myst-transforms/src/frontmatter.spec.ts
+++ b/packages/myst-transforms/src/frontmatter.spec.ts
@@ -1,0 +1,347 @@
+import type { Root } from 'mdast';
+import { getFrontmatter } from './frontmatter';
+
+describe('getFrontmatter', () => {
+  it('empty tree passes', () => {
+    const input = {
+      type: 'root',
+      children: [],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, {});
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({});
+  });
+  it('tree without block and no frontmatter passes', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, {});
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({});
+  });
+  it('tree with block and no frontmatter passes', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'block',
+          children: [
+            {
+              type: 'text',
+              value: 'hello',
+            },
+          ],
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, {});
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({});
+  });
+  it('non-yaml code block passes', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'python',
+          value: 'title: My Title',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, {});
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({});
+  });
+  it('yaml code block creates frontmatter, do not remove yaml', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'yaml',
+          value: 'title: My Title',
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, {});
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({ title: 'My Title' });
+  });
+  it('yaml code block creates frontmatter, remove yaml', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'yaml',
+          value: 'title: My Title',
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, { removeYaml: true });
+    expect(tree).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    });
+    expect(frontmatter).toEqual({ title: 'My Title' });
+  });
+  it('yaml code block creates frontmatter, remove yaml does not remove only child', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'yaml',
+          value: 'title: My Title',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, { removeYaml: true });
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({ title: 'My Title' });
+  });
+  it('title extracted from heading node, do not remove heading', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'heading',
+          depth: 1,
+          children: [
+            {
+              type: 'text',
+              value: 'Heading Title',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, {});
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({ title: 'Heading Title' });
+  });
+  it('title extracted from heading node, remove heading', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'heading',
+          depth: 1,
+          children: [
+            {
+              type: 'text',
+              value: 'Heading Title',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, { removeHeading: true });
+    expect(tree).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    });
+    expect(frontmatter).toEqual({ title: 'Heading Title' });
+  });
+  it('title extracted from heading node, remove heading does not remove only child', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'heading',
+          depth: 1,
+          children: [
+            {
+              type: 'text',
+              value: 'Heading Title',
+            },
+          ],
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, { removeHeading: true });
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({ title: 'Heading Title' });
+  });
+  it('heading title ignored if present in frontmatter', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'yaml',
+          value: 'title: My Title',
+        },
+        {
+          type: 'heading',
+          depth: 2,
+          children: [
+            {
+              type: 'text',
+              value: 'Heading Title',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, { removeHeading: true });
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({ title: 'My Title' });
+  });
+  it('heading removed if duplicates frontmatter title', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'yaml',
+          value: 'title: My Title',
+        },
+        {
+          type: 'heading',
+          depth: 1,
+          children: [
+            {
+              type: 'text',
+              value: 'My Title',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, { removeHeading: true });
+    expect(tree).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'yaml',
+          value: 'title: My Title',
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    });
+    expect(frontmatter).toEqual({ title: 'My Title' });
+  });
+  it('title is extracted from any heading if not in frontmatter', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'yaml',
+          value: 'subtitle: My Subtitle',
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+        {
+          type: 'heading',
+          depth: 5,
+          children: [
+            {
+              type: 'text',
+              value: 'Small Title',
+            },
+          ],
+        },
+        {
+          type: 'text',
+          value: 'hello',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, {});
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({ title: 'Small Title', subtitle: 'My Subtitle' });
+  });
+  it('yaml code block creates frontmatter, nested in block', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'block',
+          children: [
+            {
+              type: 'code',
+              lang: 'yaml',
+              value: 'title: My Title',
+            },
+          ],
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, {});
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({ title: 'My Title' });
+  });
+  it('yaml code block creates frontmatter, nested in block', () => {
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'block',
+          children: [
+            {
+              type: 'code',
+              lang: 'yaml',
+              value: 'title: My Title',
+            },
+          ],
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root, {});
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({ title: 'My Title' });
+  });
+});

--- a/packages/myst-transforms/src/frontmatter.ts
+++ b/packages/myst-transforms/src/frontmatter.ts
@@ -2,7 +2,7 @@ import yaml from 'js-yaml';
 import { select } from 'unist-util-select';
 import { remove } from 'unist-util-remove';
 import type { Root } from 'mdast';
-import type { Code, Heading } from 'myst-spec';
+import type { Block, Code, Heading } from 'myst-spec';
 import { toText } from 'myst-common';
 
 type Options = {
@@ -14,8 +14,10 @@ export function getFrontmatter(
   tree: Root,
   opts: Options = { removeYaml: true, removeHeading: true },
 ): { tree: Root; frontmatter: Record<string, any> } {
-  const firstNode = tree.children[0] as Code;
-  const secondNode = tree.children[1] as Heading;
+  const firstParent =
+    (tree.children[0]?.type as any) === 'block' ? (tree.children[0] as any as Block) : tree;
+  const firstNode = firstParent.children?.[0] as Code;
+  const secondNode = firstParent.children?.[1] as Heading;
   let frontmatter: Record<string, any> = {};
   const firstIsYaml = firstNode?.type === 'code' && firstNode?.lang === 'yaml';
   if (firstIsYaml) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9453731/213636985-fa32027a-e9c7-45a9-98a4-bfcfcdc509cc.png)

- Pull `metadata` from notebook cells onto blocks
- Pull metadata defined in `code` nodes onto blocks
- Use labels in that metadata to add block-level targets
- Add `embed` directive which pulls labeled nodes directly into the page