### PR TITLE
📑 Define exports as a single string

### DIFF
--- a/.changeset/thirty-spies-yawn.md
+++ b/.changeset/thirty-spies-yawn.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Allow strings in each export

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -396,10 +396,6 @@ export function validateExportsList(input: any, opts: ValidationOptions): Export
   let exports: any[];
   if (Array.isArray(input)) {
     exports = input;
-  } else if (typeof input === 'string') {
-    const format = validateExportFormat(input, opts);
-    if (!format) return undefined;
-    exports = [{ format }];
   } else {
     exports = [input];
   }
@@ -418,7 +414,14 @@ function validateExportFormat(input: any, opts: ValidationOptions): ExportFormat
 }
 
 export function validateExport(input: any, opts: ValidationOptions): Export | undefined {
-  const value = validateObject(input, opts);
+  let value;
+  if (typeof input === 'string') {
+    const format = validateExportFormat(input, opts);
+    if (!format) return undefined;
+    value = { format };
+  } else {
+    value = validateObject(input, opts);
+  }
   if (value === undefined) return undefined;
   validateKeys(
     value,

--- a/packages/myst-frontmatter/tests/exports.yml
+++ b/packages/myst-frontmatter/tests/exports.yml
@@ -78,3 +78,12 @@ cases:
       export: nope
     normalized: {}
     errors: 1
+  - title: Handle export strings
+    raw:
+      export:
+        - pdf
+        - docx
+    normalized:
+      exports:
+        - format: pdf
+        - format: docx


### PR DESCRIPTION
Exports could previously defined as:

```yaml
export: pdf
```

But not:

```yaml
export:
  - pdf
  - docx
```

This fixes up and allows the second case!