### PR TITLE
✍️ Write bibtex from citation renderers in tex export

### DIFF
--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -90,7 +90,6 @@ function writeBibtexFromCitationRenderers(session: ISession, output: string) {
   const allBibtexContent = Object.values(cache.$citationRenderers)
     .map((renderers) => {
       return Object.values(renderers).map((renderer) => {
-        console.log(renderer.cite._graph);
         const bibtexContent = (renderer.cite._graph as any[]).find((item) => {
           return item.type === '@biblatex/text';
         });
@@ -100,7 +99,6 @@ function writeBibtexFromCitationRenderers(session: ISession, output: string) {
     .flat()
     .filter((item) => !!item);
   const bibtexContent = [...new Set(allBibtexContent)].join('\n');
-  console.log(bibtexContent);
   if (!fs.existsSync(output)) fs.mkdirSync(path.dirname(output), { recursive: true });
   fs.writeFileSync(output, bibtexContent);
 }

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -16,10 +16,9 @@ import type { LinkTransformer } from 'myst-transforms';
 import { unified } from 'unified';
 import { findCurrentProjectAndLoad } from '../../config';
 import { getExportListFromRawFrontmatter, getRawFrontmatterFromFile } from '../../frontmatter';
-import { bibFilesInDir } from '../../process';
 import { loadProjectFromDisk } from '../../project';
+import { castSession } from '../../session';
 import type { ISession } from '../../session/types';
-import { selectLocalProject } from '../../store/selectors';
 import { createTempFolder } from '../../utils';
 import type { ExportWithOutput, ExportOptions } from '../types';
 import {
@@ -29,6 +28,7 @@ import {
   getSingleFileContent,
   resolveAndLogErrors,
 } from '../utils';
+import type { CitationRenderer } from 'citation-js-utils';
 
 export const DEFAULT_BIB_FILENAME = 'main.bib';
 const TEX_IMAGE_EXTENSIONS = ['.pdf', '.png', '.jpg', '.jpeg'];
@@ -85,14 +85,24 @@ export async function localArticleToTexRaw(
   writeFileToFolder(output, result.value);
 }
 
-function concatenateFiles(files: string[], output: string) {
+function writeBibtexFromCitationRenderers(session: ISession, output: string) {
+  const cache = castSession(session);
+  const allBibtexContent = Object.values(cache.$citationRenderers)
+    .map((renderers) => {
+      return Object.values(renderers).map((renderer) => {
+        console.log(renderer.cite._graph);
+        const bibtexContent = (renderer.cite._graph as any[]).find((item) => {
+          return item.type === '@biblatex/text';
+        });
+        return bibtexContent?.data;
+      });
+    })
+    .flat()
+    .filter((item) => !!item);
+  const bibtexContent = [...new Set(allBibtexContent)].join('\n');
+  console.log(bibtexContent);
   if (!fs.existsSync(output)) fs.mkdirSync(path.dirname(output), { recursive: true });
-  const fd = fs.openSync(output, 'w');
-  files.forEach((file) => {
-    fs.writeSync(fd, fs.readFileSync(file));
-    fs.writeSync(fd, '\n');
-  });
-  fs.closeSync(fd);
+  fs.writeFileSync(output, bibtexContent);
 }
 
 export async function localArticleToTexTemplated(
@@ -114,14 +124,10 @@ export async function localArticleToTexTemplated(
       extraLinkTransformers,
     },
   );
-  let bibFiles: string[];
-  if (projectPath) {
-    const { bibliography } = selectLocalProject(session.store.getState(), projectPath) || {};
-    bibFiles = bibliography || [];
-  } else {
-    bibFiles = (await bibFilesInDir(session, path.dirname(file), false)) || [];
-  }
-  concatenateFiles(bibFiles, path.join(path.dirname(templateOptions.output), DEFAULT_BIB_FILENAME));
+  writeBibtexFromCitationRenderers(
+    session,
+    path.join(path.dirname(templateOptions.output), DEFAULT_BIB_FILENAME),
+  );
 
   const mystTemplate = new MystTemplate(session, {
     kind: TemplateKind.tex,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9453731/214234438-9ed30d4a-9187-4c34-8093-f0f05e72aa51.png)

This fixes up inline DOI citations for tex/pdf exports. It is using the `cache.$citationRenderers` to write the bibtex, instead of just copying existing bibtex files (inline DOIs did not have existing bibtex files).

It's still a little klugey: we are using `renderer.cite._graph.find((item) => type === '@biblatex/text').data` (i.e. the raw text input data), rather than rebuilding the bibtex item based on structured citation data found directly on `renderer.cite`.