### PR TITLE
🐛 Show yaml errors for jtex and allow `myst: v1`

### DIFF
--- a/.changeset/breezy-otters-trade.md
+++ b/.changeset/breezy-otters-trade.md
@@ -1,0 +1,5 @@
+---
+'jtex': patch
+---
+
+Allow version to be myst: v1

--- a/.changeset/tender-stingrays-learn.md
+++ b/.changeset/tender-stingrays-learn.md
@@ -1,0 +1,5 @@
+---
+'jtex': patch
+---
+
+Print YAML errors

--- a/packages/jtex/src/cli/check.ts
+++ b/packages/jtex/src/cli/check.ts
@@ -130,13 +130,15 @@ export function checkTemplate(session: ISession, path: string, opts?: { fix?: bo
   try {
     configYaml = yaml.load(configText) as any;
   } catch (error) {
+    session.log.debug((error as Error).stack);
+    session.log.error((error as Error).message);
     throw new Error('Could not load template.yml as YAML');
   }
 
   const printWarnings = !(opts?.fix ?? false);
   const messages: Required<ValidationOptions['messages']> = { warnings: [], errors: [] };
 
-  if (configYaml.jtex !== 'v1') {
+  if (configYaml.jtex !== 'v1' && configYaml.myst !== 'v1') {
     messages.errors.push({
       property: 'jtex',
       message: 'The template.yml must have a "myst: v1" version.',


### PR DESCRIPTION
This now shows an error on yaml validation to the console rather than eating it! Also allows `myst: v1` to be defined in the template.

![image](https://user-images.githubusercontent.com/913249/214378260-ddd743f6-2f17-40bc-bc88-3a7ab94fd5fc.png)
