### PR TITLE
📖 Improve the quickstart tutorials

### DIFF
--- a/.changeset/fair-ravens-grab.md
+++ b/.changeset/fair-ravens-grab.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+The `myst init` command currently triggers on any command, this now errors and shows help!

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,11 +1,11 @@
 format: jb-book
 root: index
 parts:
-  - caption: Quickstart Guides
+  - caption: Quickstart Tutorials
     chapters:
       - file: quickstart
-      - file: quickstart-myst-documents
       - file: quickstart-myst-websites
+      - file: quickstart-myst-documents
       - file: quickstart-myst-markdown
   - caption: Authoring
     chapters:

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -5,7 +5,7 @@ description: MyST is available through Node and npm, install the package with `n
 
 +++
 
-MyST is available through [NodeJS](./installing-prerequisites.md) and the node package manager, `npm`. Node is used by Jupyter as well as many other Python packages so you may already have it installed on your *PATH* and the following command may just work 🤞.
+MyST is available through [NodeJS](./installing-prerequisites.md) and the node package manager, `npm`. Node is used by Jupyter as well as many other Python packages so you may already have it installed on your _PATH_ and the following command may just work 🤞.
 
 🛠️ [Install NodeJS](./installing-prerequisites.md) and run the following command:
 
@@ -13,11 +13,11 @@ MyST is available through [NodeJS](./installing-prerequisites.md) and the node p
 npm install -g myst-cli
 ```
 
-````{important}
+```{important}
 **Note**
 
-If you do not have `npm` installed you can look at our guide for [Installing NodeJS](./installing-prerequisites.md). If you have any challenges installing, please [open an issue here](https://github.com/executablebooks/mystjs/issues).
-````
+If you do not have `npm` installed you can look at our how to guide for [Installing NodeJS](./installing-prerequisites.md). If you have any challenges installing, please [open an issue here](https://github.com/executablebooks/mystjs/issues).
+```
 
 This will install `myst` globally (`-g`) on your system and add a link to the main CLI tool. To see if things worked, try checking the version with:
 
@@ -27,9 +27,9 @@ myst --version
 
 This command should print the current version of the package. If all is good, you can type `myst` again in your terminal and it will list the help with all of the options available to you.
 
-````{note}
+```{note}
 If you have any challenges installing, please [open an issue here](https://github.com/executablebooks/mystjs/issues).
-````
+```
 
 +++
 

--- a/docs/interactive-notebooks.ipynb
+++ b/docs/interactive-notebooks.ipynb
@@ -121,6 +121,7 @@
     }
    ],
    "source": [
+    "#| label: altair-horsepower\n",
     "points & bars"
    ]
   },

--- a/docs/quickstart-myst-documents.md
+++ b/docs/quickstart-myst-documents.md
@@ -14,9 +14,9 @@ The goal of this quickstart is to get you up and running on your local computer 
 The tutorial will be brief on explaining MyST syntax, we provide an [overview on MyST Markdown](./quickstart-myst-markdown.md) that provides more depth on syntax and pointers to other pages.
 ::::
 
-## Installing the MyST CLI 📦
-
 > 🛠 Throughout the guide, whenever you're supposed to _do_ something you will see a 🛠
+
+## Installing the MyST CLI 📦
 
 :::{card} See MyST Installation Quickstart
 :link: ./quickstart.md
@@ -103,6 +103,16 @@ A tutorial to evolve markdown documents and notebooks into structured data
 **License:** CC-BY
 ```
 
+This will produce a document that looks like:
+
+:::{figure} ./images/frontmatter-before.png
+:width: 80%
+:name: frontmatter-before-pdf
+
+The myst theme for the `01-paper.md` page using inline document and author information.
+:::
+
+
 🛠 In `01-paper.md`: Change the page frontmatter into a yaml block of _data_:
 
 ```yaml
@@ -124,13 +134,13 @@ keywords: myst, markdown, open-science
 ```
 
 In this case, we are also adding additional metadata like an ORCID, as well as ensuring the license is an SPDX compatible code.
-Once these are added, the `book-theme` template can make it look pretty, this can also be customized by other themes, including $\LaTeX$ and Microsoft Word templates!
+Once these are added, the myst theme (in this case the `book-theme` template) can make it look pretty, this can also be customized by other themes, including $\LaTeX$ and Microsoft Word templates!
 
 :::{figure} ./images/frontmatter-after.png
 :width: 80%
 :name: frontmatter-after
 
-The myst theme for the `01-paper.md` page after the frontmatter changes are added. Compare this to what it looked like before in [](#frontmatter-before). The structure of the HTML page has also been improved, including meta tags that are available to search engines and other programmatic indexers.
+The myst theme for the `01-paper.md` page after the frontmatter changes are added. Compare this to what it looked like before in [](#frontmatter-before-pdf). The structure of the HTML page has also been improved, including meta tags that are available to search engines and other programmatic indexers.
 :::
 
 ### Add an abstract block
@@ -153,7 +163,7 @@ You can make other blocks, like `data-availability` or `acknowledgements` or `ke
 
 ### Add a citation
 
-🛠 In `01-paper.md`: find the text citation for Bourne _et al._, 2012, and change it to [](doi:10.4230/DAGMAN.1.1.41)
+🛠 In `01-paper.md`: find the text citation for Bourne _et al._, 2012 (shown in `red` below), and change it to a `doi` based citation, as shown in `green` below:
 
 ```diff
 - ... follow the FORCE11 recommendations (Bourne _et al._, 2012). Specifically:
@@ -164,7 +174,14 @@ You can make other blocks, like `data-availability` or `acknowledgements` or `ke
 3. add data, software, and workflows as first-class research objects.
 ```
 
-🛠 In `01-paper.md`: find the text citation for Head _et al._ (2021), and change it to [](doi:10.1145/3411764.3445648)
+This will result in correct rendering of the citation (such as [](doi:10.4230/DAGMAN.1.1.41)), and automatic insertion into the references section.
+
+
+🛠 In `01-paper.md`: find the text citation for Head _et al._ (2021), and change it to:
+
+```bash
+[](doi:10.1145/3411764.3445648)
+```
 
 If you have replaced both of these citations, you can now safely remove the text-only, poorly formatted references section, as that is now auto generated for you!
 
@@ -183,12 +200,16 @@ See [](./citations.md) for more information about using citations and references
 
 ### Add a figure directive
 
-🛠 In `01-paper.md`: replace the image and paragraph with a figure directive
+🛠 In `01-paper.md`: replace the image and paragraph with a figure directive.
+
+Replace:
 
 ```markdown
 ![](./images/citations.png)
 **Figure 1**: Citations are rendered with a popup directly inline.
 ```
+
+with:
 
 ```markdown
 :::{figure} ./images/citations.png
@@ -256,11 +277,14 @@ flowchart LR
 
 By writing in MyST, you can export directly to these formats.
 Using MyST will also allow you to support interactive, computational media -- things that will **never** make it to the PDF!!
+
+Help support the transition to FAIR[^fair], open science by preferring web-based formats and publishing your own work on the web.
+
 ::::
 
 ### Microsoft Word Documents
 
-🛠 In the `01-paper.md` frontmatter: add `export: docx`
+🛠 In the `01-paper.md` add `export: docx` to the existing frontmatter section:
 
 ```yaml
 ---
@@ -270,10 +294,12 @@ export: docx
 
 🛠 Run `myst build --docx`
 
-The export process will run for any known files with `docx`, an equivalent command for this specific file is:\
-`myst build 01-paper.md`\
-By default, the build command only builds the site content, to build all exports for the project, use:\
-`myst build --all`
+```bash
+myst build --docx
+```
+
+The export process will run for any known files with `docx` specified in the `export` frontmatter. An equivalent command to export only this specific file is: 
+`myst build 01-paper.md`
 
 ```text
 📬 Performing exports:
@@ -285,13 +311,15 @@ By default, the build command only builds the site content, to build all exports
 📄 Exported DOCX in 166 ms, copying to _build/exports/paper.docx
 ```
 
-In this case, the default word template was used, we will see in working with $\LaTeX$ next, how to add additional exports as well as change the template!
+In this case, the default word template was used, resulting in a document formatted like this:
 
 :::{figure} ./images/export-docx.png
 :name: export-docx
 :width: 80%
 Exporting your article to `docx` using `myst export --docx`.
 :::
+
+Next we will see how to change the template as well as how to add additional exports when working with $\LaTeX$ and PDF!
 
 :::{seealso}
 See [](./creating-word-documents.md) to learn about exporting to `*.docx`, for example some intricacies around equations!
@@ -300,7 +328,8 @@ See [](./creating-word-documents.md) to learn about exporting to `*.docx`, for e
 ### Exporting to PDF
 
 To export to PDF, MyST currently requires $\LaTeX$ to be installed. See [](./creating-pdf-documents.md) for more information about how to install $\LaTeX$.
-First, we need to know which template to export to, for this, we will use the `myst templates` command, and for example listing all the two-column, PDF templates.
+
+First, we need to decide which template to export to, for this, we will use the `myst templates` command, and for example list all the two-column, PDF templates available.
 
 🛠 List all two column PDF templates with: `myst templates list --pdf --tag two-column`
 
@@ -314,7 +343,7 @@ Description: A template for submissions to the Volcanica journal
 Tags: paper, journal, two-column, geoscience, earthscience
 ```
 
-🛠 List the specific information needed for a template: `myst templates list volcanica --pdf`
+🛠 Then, list the specific information needed for a template: `myst templates list volcanica --pdf`
 
 ```text
 Volcanica                volcanica
@@ -334,6 +363,8 @@ Options:
 article_type (choice) - Details about different article types...
 ```
 
+In addition basic information on the template, the template's specific "parts" and "options" are shown. Some of these may be marked as `(required)` and be essential for the building the document correctly with the template.
+
 🛠 In `01-paper.md`: replace `export: docx` with a list:
 
 ```yaml
@@ -346,8 +377,9 @@ exports:
 ---
 ```
 
-We have added additional information to the second PDF export, to specify the template as well as add additional information about the `article_type`, which is information we discovered when listing the template above!
-You can now build the PDF with the `myst build` command:
+We have added a second export target for `pdf` and included additional information to specify the template, as well as set the `article_type` option, which is information we discovered when listing the template above! We also saw this template supports a number of "parts" including a required `abstract` part, but as we already added a `abstract` part earlier in this tutorial, we are good to go.
+
+You can now build the exports with the following command:
 
 🛠 Run `myst build 01-paper.md`
 
@@ -363,7 +395,7 @@ You can now build the PDF with the `myst build` command:
 📄 Exported PDF in 9.3 s, copying to _build/exports/paper.pdf
 ```
 
-You can now see your two-column PDF in a submission ready format for the journal. It is very easy to change the template to a different format -- just change the `template:`!
+You can now see your two-column PDF in a submission ready format for the journal (check the `_build/exports` folder). It is very easy to change the template to a different format -- just change the `template:` field in the frontmatter!
 Notice also that the PDF has converted dynamic images to a static alternative (e.g. GIFs are now PNGs).
 
 :::{figure} ./images/export-pdf.png
@@ -409,10 +441,18 @@ Creating a zip file can be helpful when directly submitted to the arXiv or a jou
 
 ## Conclusion 🥳
 
-That's it for this quickstart guide!! In the next tutorial we will have more information about working with Jupyter Notebooks, and sharing outputs and cells between your documents!
-As next steps for working with documents, we recommend looking at:
+That's it for this quickstart guide!!
+
+As next steps for specifically working with documents, we recommend looking at:
 
 :::{card} MyST Markdown Overview
 :link: ./quickstart-myst-markdown.md
 A high-level of all of the syntax available to your for working with the MyST Markdown language.
+:::
+
+To learn more about the specifics of creating MyST websites:
+
+:::{card} MyST Websites
+:link: ./quickstart-myst-websites.md
+Create a website like this one.
 :::

--- a/docs/quickstart-myst-documents.md
+++ b/docs/quickstart-myst-documents.md
@@ -1,6 +1,6 @@
 ---
 title: Working with MyST Documents
-subject: MyST Quickstart
+subject: MyST Quickstart Tutorial
 subtitle: Export to PDF, Word and LaTeX
 short_title: MyST Documents
 description: Get up and running with the MyST (Markedly Structured Text) command line interface. MyST is designed to create publication-quality documents written entirely in Markdown.
@@ -11,27 +11,17 @@ description: Get up and running with the MyST (Markedly Structured Text) command
 
 The goal of this quickstart is to get you up and running on your local computer 👩‍💻, improve a markdown document to add MyST features, and then export to Microsoft Word 📄 and (if you have LaTeX installed) a scientific PDF template 📜.
 
-The tutorial will be brief on explaining MyST syntax, we provide an [overview on MyST Markdown](./quickstart-myst-markdown.md) that provides more depth on syntax and pointers to other pages.
+The tutorial will be brief on explaining MyST syntax, we provide a [MyST Markdown Guide](./quickstart-myst-markdown.md) that provides more depth on syntax and pointers to other resources.
 ::::
 
-> 🛠 Throughout the guide, whenever you're supposed to _do_ something you will see a 🛠
+![](#lookout-for-tutorial-actions)
 
-## Installing the MyST CLI 📦
+![](#install-myst-dropdown)
 
-:::{card} See MyST Installation Quickstart
-:link: ./quickstart.md
-See the first quickstart guide for installation walk-through and installation prerequisites.
-:::
+:::{tip}
+:class: dropdown
 
-🛠 Install the MyST command line tools:
-
-```bash
-npm install -g myst-cli
-```
-
-If you have any problems, see [installing MyST](./installing.md) and or [open an issue here](https://github.com/executablebooks/mystjs/issues/new?assignees=&labels=bug&template=bug_report.yml). 🐛
-
-## Download example content
+## 🛠 Download quickstart content
 
 We are going to download an example project that includes a few simple markdown files and some Jupyter Notebooks.
 Our goal will be to try out some of the main features of `myst`, improve the structure of the document, learn the basics of MyST Markdown for figures, citations, and cross-references, and export to a Word document, PDF and $\LaTeX$.
@@ -43,42 +33,52 @@ git clone https://github.com/executablebooks/mystjs-quickstart.git
 cd mystjs-quickstart
 ```
 
-## Initialize MyST 🚀
+:::
 
-Next we will create `myst.yml` configuration files that is required to render your project.
+::::{tip}
+:class: dropdown
 
-🛠 Run `myst`
+## 🛠 Create and edit a MyST Website (optional)
 
-The `myst` command is a shortcut for `myst init`, which has a few more options for writing specific parts of the configuration file and a table of contents for your site.
+In the previous tutorial we ran `myst init`, installed the default `book-theme` template for the website, and improved the style of the website.
+
+:::{card} 🛠 Complete the MyST Website tutorial
+:link: ./quickstart-myst-websites.md
+Get up and running on your local computer 👩‍💻, create a local website 🌎, and edit elements of the theme to improve the website style 🎨.
+:::
+
+To start this tutorial directly, when you run `myst` the first time, the install will take a little longer to install the `book-theme`, otherwise you should be good to go!
+::::
+
+## Start MyST 🚀
+
+From the previous tutorial, you should already have created a `myst.yml` configuration file that is required to render your project. If you have not done that tutorial, type `myst` and follow the directions to start the server, otherwise:
+
+🛠 Run `myst start`
+
+If this is the first time you have run `myst start`, the theme will be installed (takes 15-30 seconds), and then bring up a local web-server that shows you a live preview of your documents as you are writing them! every time you save a few milliseconds later the server will update.
 
 ```text
-> myst
+📖 Built README.md in 33 ms.
+📖 Built 01-paper.md in 30 ms.
+📖 Built 02-notebook.ipynb in 6.94 ms.
+📚 Built 3 pages for myst in 76 ms.
 
-Welcome to the MyST CLI!! 🎉 🚀
+      ✨✨✨  Starting Book Theme  ✨✨✨
 
-myst init walks you through creating a myst.yml file.
+⚡️ Compiled in 510ms.
 
-You can use myst to:
+🔌 Server started on port 3000!  🥳 🎉
 
- - create interactive websites from markdown and Jupyter Notebooks 📈
- - build & export professional PDFs and Word documents 📄
-
-Learn more about this CLI and MyST Markdown at: https://myst.tools
-
-💾 Writing new project and site config file: myst.yml
+      👉  http://localhost:3000  👈
 ```
 
-🛠 When prompted, type `No`
+🛠 Open your web browser to `http://localhost:3000`[^open-port]
 
-```bash
-? Would you like to run "myst start" now? No
-```
+[^open-port]: If port `3000` is in use on your machine, an open port will be used instead, follow the link provided in the terminal.
 
-:::{seealso}
-To explore `myst start` see the quickstart guide on [](./quickstart-myst-websites.md)!
-
-In this quickstart guide we will focus on creating printed documents!
-:::
+To fully explore `myst start` see the first quickstart tutorial on [](./quickstart-myst-websites.md).
+In this quickstart tutorial we will focus on creating printed documents! 📑
 
 ## Use MyST Markdown! 🎉
 
@@ -111,7 +111,6 @@ This will produce a document that looks like:
 
 The myst theme for the `01-paper.md` page using inline document and author information.
 :::
-
 
 🛠 In `01-paper.md`: Change the page frontmatter into a yaml block of _data_:
 
@@ -175,7 +174,6 @@ You can make other blocks, like `data-availability` or `acknowledgements` or `ke
 ```
 
 This will result in correct rendering of the citation (such as [](doi:10.4230/DAGMAN.1.1.41)), and automatic insertion into the references section.
-
 
 🛠 In `01-paper.md`: find the text citation for Head _et al._ (2021), and change it to:
 
@@ -298,7 +296,7 @@ export: docx
 myst build --docx
 ```
 
-The export process will run for any known files with `docx` specified in the `export` frontmatter. An equivalent command to export only this specific file is: 
+The export process will run for any known files with `docx` specified in the `export` frontmatter. An equivalent command to export only this specific file is:\
 `myst build 01-paper.md`
 
 ```text
@@ -441,7 +439,7 @@ Creating a zip file can be helpful when directly submitted to the arXiv or a jou
 
 ## Conclusion 🥳
 
-That's it for this quickstart guide!!
+That's it for this quickstart tutorial!!
 
 As next steps for specifically working with documents, we recommend looking at:
 

--- a/docs/quickstart-myst-markdown.md
+++ b/docs/quickstart-myst-markdown.md
@@ -1,19 +1,19 @@
 ---
 title: Working with MyST Markdown
-subject: MyST Quickstart
+subject: MyST Quickstart Guide
 subtitle: An overview of syntax features
-short_title: MyST Markdown
+short_title: MyST Markdown Guide
 description: MyST (Markedly Structured Text) is designed to create publication-quality documents written entirely in Markdown.
 ---
 
 :::{important}
 **Objective**
 
-The goal of this quickstart is to showcase the most used features of the MyST authoring experience. The MyST syntax can be used in markdown files or markdown cells in Jupyter Notebooks to add figures, tables, equations, cross-references, hover-links and citations.
+The goal of this quickstart guide is to showcase the most used features of the MyST authoring experience. The MyST syntax can be used in markdown files or markdown cells in Jupyter Notebooks to add figures, tables, equations, cross-references, hover-links and citations.
 :::
 
 :::{tip}
-During this guide, you can make changes and experiment with MyST syntax in the editors included directly on the page.
+During this how to guide, you can make changes and experiment with MyST syntax in the editors included directly on the page.
 :::
 
 ## Overview
@@ -96,12 +96,12 @@ See [](./frontmatter.md) for all options, how to use frontmatter in various tool
 
 ## Links & Cross-References
 
-As you have seen in the links in MyST (e.g. [](./frontmatter.md)), there is information that is pulled forward into your reading context on hover or click. We believe it is important to provide as much possible context when you are reading on elements like links to other pages, cross-references to figures, tables and equations as well as traditional academic citations[^contextual-information]. Additionally, all of these have fallbacks in static PDF or Word documents.
+As you have seen in the links in MyST (e.g. [](./frontmatter.md)), there is information that is pulled forward into your reading context on hover or click. We believe it is important to provide as much possible context when you are reading on elements like links to other pages, cross-references to figures, tables and equations as well as traditional academic citations[^contextual-information] (**👈 click the footnote!**). Additionally, all of these have fallbacks in static PDF or Word documents.
 
 [^contextual-information]:
     For example, in [](doi:10.1145/3411764.3445648) the authors showed you can speed up comprehension of a paper by 26% when showing information in context, rather than requiring researchers to scroll back and forth to find figures and equations.
 
-    Imagine if all of science was ⚡️ 26% faster ⚡️[^3]!!\
+    Imagine if all of science was ⚡️ 26% faster ⚡️[^3]!! (**👈💥**)\
     Designing the user-experience of scientific communication is _really_ important.
 
 [^3]:
@@ -110,9 +110,9 @@ As you have seen in the links in MyST (e.g. [](./frontmatter.md)), there is info
     :::{iframe} https://www.youtube.com/embed/yYcQf-Yq8B0
     :::
 
-    Can't do that in a PDF! [^4]
+    Can't do that in a PDF! [^4] (**👈💥**)
 
-[^4]: I mean, now that you are down the rabbit-hole, we can get you back on track with a demo of [referencing equations](#example-equation-targets), or just click back on the page to get back to where you were!
+[^4]: I mean, now that you are down the rabbit-hole, we can get you back on track with a demo of [referencing equations](#example-equation-targets) (**👈💥**), or just click back on the page to get back to where you were!
 
 To link to a document, for example [](./frontmatter.md), is done through a simple Markdown link `[](./frontmatter.md)`, you can put your own content in between the square brackets, but if you leave it out the link contents will be filled in with the title of the page. If you define the frontmatter on that page (i.e. the description and tooltip), you will also see that information when you hover over the link. This also works for links to Wikipedia (e.g. [Ponyies 🐴](https://en.wikipedia.org/wiki/New_Forest_pony)) as well as Github code (e.g. [](https://github.com/executablebooks/mystjs/blob/main/README.md)).
 

--- a/docs/quickstart-myst-markdown.md
+++ b/docs/quickstart-myst-markdown.md
@@ -12,6 +12,10 @@ description: MyST (Markedly Structured Text) is designed to create publication-q
 The goal of this quickstart is to showcase the most used features of the MyST authoring experience. The MyST syntax can be used in markdown files or markdown cells in Jupyter Notebooks to add figures, tables, equations, cross-references, hover-links and citations.
 :::
 
+:::{tip}
+During this guide, you can make changes and experiment with MyST syntax in the editors included directly on the page.
+:::
+
 ## Overview
 
 MyST (Markedly Structured Text) is designed to create publication-quality documents written entirely in Markdown. The extensions and design of MyST is inspired by the [Sphinx](https://www.sphinx-doc.org/) and [ReStructured Text](https://docutils.sourceforge.io/rst.html) (RST) ecosystems and is is a superset of [CommonMark](./commonmark.md).
@@ -43,7 +47,7 @@ See [](./typography.md) to learn in depth about all typographical elements. The 
 
 Directives are multi-line containers that include an identifier, arguments, options, and content. Examples include [admonitions](./admonitions.md), [figures](./figures.md), and [equations](./math.md). At its simplest, you can use directives using a "fence" (either [back-ticks or colons](#example-fence)) and the name of the directive enclosed in braces (`{name}`).
 
-For example, try editing the following `{figure}` directive, you can center the figure with an `:align: center` option!
+For example, try editing the following `{figure}` directive, you can center the figure with an `:align: center` option or change the `colons` for `backticks`.
 
 ```{myst}
 

--- a/docs/quickstart-myst-websites.md
+++ b/docs/quickstart-myst-websites.md
@@ -135,12 +135,12 @@ quickstart/
   └── 🆕 myst.yml
 ```
 
-The additions are:
+Running `myst init` added:
 
 - `myst.yml` - the configuration file for your myst project and site
 - `_build` - the folder containing the processed content and other `site` assets, which are used by the local web server.
 
-The `_build` folder contains your templates (including the site template you installed). When we build a PDF the exported document will show up in the `_build/exports` folder. You can clean up the built files at any time using `myst clean`[^clean-all].
+The `_build` folder also contains your templates (including the site template you installed) and any exports you make (when we build a PDF the exported document will show up in the `_build/exports` folder). You can clean up the built files at any time using `myst clean`[^clean-all].
 
 [^clean-all]:
     By default the `myst clean` command doesn't remove installed templates, however, the function can with a `myst clean --all` or `myst clean --templates`.
@@ -192,9 +192,9 @@ There are two important parts to the `myst.yml`:
 : The project holds metadata about the collection of files, such as authors, affiliations and licenses for all of the files, any of these values can optionally be overridden in a file. To see all of the options see [](./frontmatter.md), which includes which fields can be overridden by files in the project.
 
 `site:`
-: The site holds template information about the website, such as the logo, navigation, site actions and which template to use. The site has a list of projects, in this case the `path: .` looks to the current configuration file for the project, which sill be "mounted" at the `slug:` (i.e. `/myst/`); sites can have multiple projects.
+: The site holds template information about the website, such as the logo, navigation, site actions and which template to use. The site has a list of projects, in this case the `path: .` looks to the current configuration file for the project, which will be "mounted" at the `slug:` (i.e. `/myst/`); sites can have multiple projects.
 
-🛠 In `myst.yml`: Change the **site** "`# title:`" to "`title: Fancy Title 🎩`" and save
+🛠 In `myst.yml`: Change the "`# title:`" comment in **site** to "`title: Fancy Title 🎩`" and save
 
 Saving the `myst.yml` will have triggered a "full site rebuild"[^myst-start] and in about ⚡️ 20ms ⚡️ take a look at the browser tab:
 

--- a/docs/quickstart-myst-websites.md
+++ b/docs/quickstart-myst-websites.md
@@ -1,7 +1,7 @@
 ---
 title: Working with MyST Websites
 subtitle: Create a website like this one
-subject: MyST Quickstart
+subject: MyST Quickstart Tutorial
 short_title: MyST Websites
 description: A MyST project is collection of MyST markdown files and jupyter notebooks with a configuration file called "myst.yml".
 ---
@@ -11,27 +11,33 @@ description: A MyST project is collection of MyST markdown files and jupyter not
 
 The goal of this quickstart is to get you up and running on your local computer 👩‍💻, create a local website 🌎, and edit elements of the theme to improve the website style 🎨.
 
-The tutorial will be brief on explaining MyST syntax, we provide an [overview on MyST Markdown](./quickstart-myst-markdown.md) that provides more depth on syntax and pointers to other pages.
+The tutorial will be brief on explaining MyST syntax, we provide a [MyST Markdown Guide](./quickstart-myst-markdown.md) that provides more depth on syntax and pointers to other resources.
 ::::
 
-## Installing the MyST CLI 📦
+![](#lookout-for-tutorial-actions)
 
-> 🛠 Throughout the guide, whenever you're supposed to _do_ something you will see a 🛠
+(install-myst-dropdown)=
+::::{tip}
+:class: dropdown
 
-:::{card} See MyST Installation Quickstart
-:link: ./quickstart.md
-See the first quickstart guide for installation walk-through and installation prerequisites.
-:::
+## 🛠 Install the MyST CLI
 
-🛠 Install the MyST command line tools:
+🛠 Install the MyST command line tools, with `node` **greater than version v16**:
 
 ```bash
 npm install -g myst-cli
 ```
 
-If you have any problems, see [installing MyST](./installing.md) and or [open an issue here](https://github.com/executablebooks/mystjs/issues/new?assignees=&labels=bug&template=bug_report.yml). 🐛
+:::{card} Need more help? See MyST Installation Quickstart
+:link: ./quickstart.md
+See the first quickstart tutorial for installation walk-through and installation prerequisites.
+:::
+::::
 
-## Download example content
+:::{tip}
+:class: dropdown
+
+## 🛠 Download quickstart content
 
 We are going to download an example project that includes a few simple markdown files and some Jupyter Notebooks.
 Our goal will be to try out some of the main features of `myst` to create a website like this one, improve the structure of the metadata, share it between pages, and improve the website theme.
@@ -43,9 +49,11 @@ git clone https://github.com/executablebooks/mystjs-quickstart.git
 cd mystjs-quickstart
 ```
 
+:::
+
 ## Initialize MyST 🚀
 
-Next we will create `myst.yml` configuration files that is required to render your project.
+Next we will create a `myst.yml` configuration file that is required to render your project.
 
 🛠 Run `myst`
 
@@ -101,7 +109,7 @@ The theme will now install using `node` and `npm`, this can take **up to a minut
 
 [^open-port]: If port `3000` is in use on your machine, an open port will be used instead, follow the link provided in the terminal.
 
-The example site in this tutorial only has three pages and by default the `01-paper.md` page looks like this:
+The example site in this tutorial only has three pages and by default the `01-paper.md` page is seen in [](#frontmatter-before), which has minimal styles applied to the content.
 
 :::{figure} ./images/frontmatter-before.png
 :width: 50%
@@ -143,9 +151,11 @@ Running `myst init` added:
 The `_build` folder also contains your templates (including the site template you installed) and any exports you make (when we build a PDF the exported document will show up in the `_build/exports` folder). You can clean up the built files at any time using `myst clean`[^clean-all].
 
 [^clean-all]:
-    By default the `myst clean` command doesn't remove installed templates, however, the function can with a `myst clean --all` or `myst clean --templates`.
+    By default the `myst clean` command doesn't remove installed templates, however, the function can with a:\
+    `myst clean --all`, or\
+    `myst clean --templates`.
 
-    Before deleting any folders you will confirm what is going to happen, or bypass this with the `-y` option. For example:
+    Before deleting any folders `myst` will confirm what is going to happen, or you can bypass this confirmation with the `-y` option. For example:
 
     ```text
     Deleting all the following paths:
@@ -154,6 +164,7 @@ The `_build` folder also contains your templates (including the site template yo
       - _build/templates
 
     ? Would you like to continue? Yes
+
     🗑 Deleting: _build/site
     🗑 Deleting: _build/templates
     ```
@@ -213,12 +224,38 @@ The site title will control site meta tags, and the browser-tab title, which is 
 To see all of the options see [](./frontmatter.md), which includes which fields can be overridden by files in the project.
 :::
 
-A MyST project is collection of MyST markdown files and Jupyter Notebooks with a configuration file `myst.yml` in the root directory. These files may be structured by defining an explicit [table of contents](./table-of-contents.md) `_toc.yml` in the same directory as the configuration file, or MyST will infer the structure from the directory structure. The project config may define a specific file to be the `index` file; it may also define a list of files to `exclude`.
+---
 
-Aside from structuring your project, the project config in `myst.yml` defines project [frontmatter](./frontmatter.md), fields such as `author`, `keywords`, etc. This frontmatter applies to all pages in the project and may be substituted when the corresponding field is not defined on the page.
+More Coming Soon™
 
-You may use the `myst init` command to initialize a MyST project in an existing directory.
+- logos
+- table of contents ([](./table-of-contents.md))
+- actions
+- themes
 
-## MyST Site
+---
 
-A site configuration may also be defined in a `myst.yml` file. A site can reference one or more projects, defines additional frontmatter, and provides templating settings to build websites.
+## Conclusion 🥳
+
+For now, that's it for this quickstart tutorial, we will add more about changing logos, themes, the table of contents, and much more soon!
+As for next steps you can export MyST Markdown as traditional documents like PDFs and Word, take a look at:
+
+:::{card} MyST Documents 📑
+:link: ./quickstart-myst-documents.md
+Learn the basics of MyST Markdown, and export to a Word document, PDF, and $\LaTeX$!
+:::
+
+:::{card} MyST Markdown Guide 📖
+:link: ./quickstart-myst-markdown.md
+See an overview of MyST Markdown syntax with inline demos and examples.
+:::
+
+% A MyST project is collection of MyST markdown files and Jupyter Notebooks with a configuration file `myst.yml` in the root directory. These files may be structured by defining an explicit [table of contents](./table-of-contents.md) `_toc.yml` in the same directory as the configuration file, or MyST will infer the structure from the directory structure. The project config may define a specific file to be the `index` file; it may also define a list of files to `exclude`.
+
+% Aside from structuring your project, the project config in `myst.yml` defines project [frontmatter](./frontmatter.md), fields such as `author`, `keywords`, etc. This frontmatter applies to all pages in the project and may be substituted when the corresponding field is not defined on the page.
+
+% You may use the `myst init` command to initialize a MyST project in an existing directory.
+
+% ## MyST Site
+
+% A site configuration may also be defined in a `myst.yml` file. A site can reference one or more projects, defines additional frontmatter, and provides templating settings to build websites.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Installing MyST Command Line Tools
 subtitle: Work locally with MyST documents and notebooks
-subject: MyST Quickstart
+subject: MyST Quickstart Tutorial
 short_title: MyST Install
 description: Get up and running with the MyST (Markedly Structured Text) command line interface. MyST is designed to create publication-quality documents written entirely in Markdown.
 ---
@@ -9,13 +9,13 @@ description: Get up and running with the MyST (Markedly Structured Text) command
 ::::{important}
 **Objective**
 
-The goal of these quickstart guides are to get you up and running on your local computer 👩‍💻:
+The goal of these quickstart tutorials are to get you up and running on your local computer 👩‍💻:
 
 - learn how to write MyST Markdown 🖊
 - export PDF, Word and $\LaTeX$ documents 📑
 - and create a website like this one 🌎
 
-The guides and in the form of tutorials and will be brief on explaining MyST syntax, but we include an [overview on MyST Markdown](./quickstart-myst-markdown.md) providing more depth on syntax and pointers to other pages.
+The tutorials will be brief on explaining MyST syntax, but we include an [MyST Markdown Guide](./quickstart-myst-markdown.md) providing more depth on syntax and pointers to other pages.
 
 :::{note}
 :class: dropdown
@@ -31,7 +31,7 @@ The content that you build is compatible between tools in the MyST ecosystem, ho
 
 ## Prerequisites
 
-To follow along with this quickstart guide on your own computer, it is helpful if you have some familiarity with using the command line, as well as using a text editor and/or JupyterLab.
+To follow along with this quickstart tutorial on your own computer, it is helpful if you have some familiarity with using the command line, as well as using a text editor and/or JupyterLab.
 
 Additionally, you should have these programs installed:
 
@@ -43,9 +43,11 @@ If the node ecosystem is new to you[^conda], see our getting started guides for 
 
 [^conda]: If you have experience in Conda installations, we would _love_ your help to get the MyST install process into a form that most Pythonistas are familiar with!! See [GitHub issue](https://github.com/executablebooks/mystjs/issues/139) 🙏 🐍 🚀
 
-## Installing the MyST CLI 📦
+(lookout-for-tutorial-actions)=
 
-> 🛠 Throughout the guides, whenever you're supposed to _do_ something you will see a 🛠
+> 🛠 Throughout the tutorial, whenever you're supposed to _do_ something you will see a 🛠
+
+## Installing the MyST CLI 📦
 
 The `myst-cli` is a command line interface (CLI) that provides modern tooling for technical writing, reproducible science, and creating scientific & technical websites. To get started install `myst-cli`.
 
@@ -78,18 +80,23 @@ cd mystjs-quickstart
 
 [^no-git]: If you aren't familiar with git, it isn't required for this tutorial, you can download the zip file with the contents from the [quickstart repository](https://github.com/executablebooks/mystjs-quickstart).
 
-## Choose a guide 🚀
+## Go through the tutorials 🚀
 
-You are well on your way to getting started with `myst`, choose what you want to do next!
+You are well on your way to getting started with `myst` the tutorials are written to go through in order, however, you can also jump in
 
-🛠 Click a card below to take you on a `myst`ical journey! 🃏 🎲
+🛠 Choose a quickstart tutorial to go on a `myst`ical journey! 🃏 🎲
+
+:::{card} MyST Websites 🌎
+:link: ./quickstart-myst-websites.md
+Learn the basics of customizing a MyST Website, including sharing frontmatter between pages.
+:::
 
 :::{card} MyST Documents 📑
 :link: ./quickstart-myst-documents.md
 Learn the basics of MyST Markdown, and export to a Word document, PDF, and $\LaTeX$!
 :::
 
-:::{card} MyST Websites 🌎
-:link: ./quickstart-myst-websites.md
-Learn the basics of customizing a MyST Website, including sharing frontmatter between pages.
+:::{card} MyST Markdown Guide 📖
+:link: ./quickstart-myst-markdown.md
+See an overview of MyST Markdown syntax with inline demos and examples.
 :::

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,23 +15,23 @@ The goal of these quickstart guides are to get you up and running on your local 
 - export PDF, Word and $\LaTeX$ documents 📑
 - and create a website like this one 🌎
 
-The tutorials will be brief on explaining MyST syntax, we provide an [overview on MyST Markdown](./quickstart-myst-markdown.md) that provides more depth on syntax and pointers to other pages.
+The guides and in the form of tutorials and will be brief on explaining MyST syntax, but we include an [overview on MyST Markdown](./quickstart-myst-markdown.md) providing more depth on syntax and pointers to other pages.
 
 :::{note}
 :class: dropdown
 **Looking for JupyterBook docs?**
 
-The `myst` CLI is not the same as [JupyterBook](https://jupyterbook.org/), which uses Sphinx as the documentation engine!
+The `myst` CLI is not the same as [JupyterBook](https://jupyterbook.org/), which uses the Sphinx documentation engine!
 You can read about the [history of `mystjs` development](./background.md).
 The content that you build is compatible between tools in the MyST ecosystem, however, this tutorial focuses on the `mystjs` tools and CLI.
 
-The main capability of `mystjs` beyond JupyterBook is export to scientific PDF documents, and you can use the two tools together! 💚
+`mystjs` has capabilities beyond JupyterBook, for example exporting to scientific PDF documents, and you can use the two tools together! 💚
 :::
 ::::
 
 ## Prerequisites
 
-To follow along with this tutorial on your own computer, it is helpful if you have some familiarity with using the command line, as well as using a text editor and/or JuptyerLab.
+To follow along with this quickstart guide on your own computer, it is helpful if you have some familiarity with using the command line, as well as using a text editor and/or JupyterLab.
 
 Additionally, you should have these programs installed:
 
@@ -67,7 +67,7 @@ If you have any problems, see [installing MyST](./installing.md) and or [open an
 ## Download example content
 
 We provide an example project that includes a few simple markdown files and some Jupyter Notebooks.
-The project is **not** a good example of how to use MyST, it is a project that you will use throughout the tutorials to improve the metadata, add export targets, and create a website!
+In it's initial state, the project is **not** a good example of how to use MyST, but through the course of the tutorials you will correct that by improving the metadata, adding export targets, and creating a website!
 
 🛠 Download the example content[^no-git], and navigate into the folder:
 
@@ -80,7 +80,7 @@ cd mystjs-quickstart
 
 ## Choose a guide 🚀
 
-You are well on your way to getting started with `myst`, next up, choose what you want to do next!
+You are well on your way to getting started with `myst`, choose what you want to do next!
 
 🛠 Click a card below to take you on a `myst`ical journey! 🃏 🎲
 

--- a/packages/myst-cli/src/cli/clirun.ts
+++ b/packages/myst-cli/src/cli/clirun.ts
@@ -27,9 +27,7 @@ export function clirun(
     try {
       await func(session, ...args.slice(0, nArgs));
     } catch (error) {
-      if (opts.debug) {
-        session.log.debug(`\n\n${(error as Error)?.stack}\n\n`);
-      }
+      session.log.debug(`\n\n${(error as Error)?.stack}\n\n`);
       session.log.error((error as Error).message);
       logVersions(session, versions, false);
       process.exit(1);

--- a/packages/myst-cli/src/cli/index.ts
+++ b/packages/myst-cli/src/cli/index.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander';
 import version from '../version';
 import { makeBuildCLI } from './build';
 import { makeCleanCLI } from './clean';
-import { makeInitCLI } from './init';
+import { makeInitCLI, addDefaultCommand } from './init';
 import { makeStartCLI } from './site';
 import { makeTemplatesCLI } from './templates';
 
@@ -16,4 +16,5 @@ program.addCommand(makeTemplatesCLI(program));
 program.addCommand(makeCleanCLI(program));
 program.version(`v${version}`, '-v, --version', 'Print the current version of myst');
 program.option('-d, --debug', 'Log out any errors to the console');
+addDefaultCommand(program);
 program.parse(process.argv);

--- a/packages/myst-cli/src/cli/init.ts
+++ b/packages/myst-cli/src/cli/init.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import { init } from '../build';
 import { Session } from '../session';
@@ -18,7 +19,19 @@ export function makeInitCLI(program: Command) {
     .addOption(makeSiteOption('Initialize config for MyST site'))
     .addOption(makeWriteTocOption())
     .action(clirun(Session, init, program));
-  // The default command runs `myst init`
-  program.action(clirun(Session, init, program));
   return command;
+}
+
+// The default command runs `myst init` with no arguments
+export function addDefaultCommand(program: Command) {
+  program.action(async (...args: any[]) => {
+    if (program.args.length === 0) return clirun(Session, init, program)(args);
+    console.error(
+      `${chalk.red(`Invalid command: `)}${chalk.bold(program.args.join(' '))}\n\n${chalk.dim(
+        'See --help for a list of available commands.\n',
+      )}`,
+    );
+    console.log(program.helpInformation());
+    process.exit(1);
+  });
 }

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -297,7 +297,15 @@ export async function processProject(
 }
 
 export async function processSite(session: ISession, opts?: ProcessOptions): Promise<boolean> {
-  reloadAllConfigsForCurrentSite(session);
+  try {
+    reloadAllConfigsForCurrentSite(session);
+  } catch (error) {
+    session.log.debug(`\n\n${(error as Error)?.stack}\n\n`);
+    session.log.error(
+      `Could not find configuration files, do you need to run ${chalk.bold('myst init')}?`,
+    );
+    process.exit(1);
+  }
   const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
   session.log.debug(`Site Config:\n\n${yaml.dump(siteConfig)}`);
   if (!siteConfig?.projects?.length) return false;


### PR DESCRIPTION
- [x] use "tutorial" (i.e. quickstart tutorial), not guide (in line with https://diataxis.fr/)
- [x] Do the website quickstart first (this is more in line with getting an early preview that works out of the box)
- [x] Encourage the user to start the webserver in the document tutorial, but focus on the live-preview rather than the customization of the website.