### PR TITLE
📤 Support embeded cross references and output images/text in file exports

### DIFF
--- a/.changeset/few-beers-shop.md
+++ b/.changeset/few-beers-shop.md
@@ -1,0 +1,7 @@
+---
+'myst-cli': patch
+'myst-to-docx': patch
+'myst-to-tex': patch
+---
+
+Embeded content from other pages resolves on single page PDF/docx export

--- a/.changeset/sweet-colts-vanish.md
+++ b/.changeset/sweet-colts-vanish.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Output nodes are reduced to simpler image/code nodes for static PDF/docx exports

--- a/packages/myst-cli/src/build/docx/single.ts
+++ b/packages/myst-cli/src/build/docx/single.ts
@@ -27,6 +27,8 @@ import { createFooter } from './footers';
 import { createArticleTitle, createReferenceTitle } from './titles';
 import { TemplateKind } from 'myst-common';
 
+const DOCX_IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg'];
+
 export async function collectWordExportOptions(
   session: ISession,
   file: string,
@@ -159,6 +161,7 @@ export async function runWordExport(
   if (clean) cleanOutput(session, output);
   const data = await getSingleFileContent(session, file, createTempFolder(session), {
     projectPath,
+    imageExtensions: DOCX_IMAGE_EXTENSIONS,
     extraLinkTransformers,
   });
   const vfile = new VFile();

--- a/packages/myst-cli/src/build/tex/single.ts
+++ b/packages/myst-cli/src/build/tex/single.ts
@@ -28,7 +28,6 @@ import {
   getSingleFileContent,
   resolveAndLogErrors,
 } from '../utils';
-import type { CitationRenderer } from 'citation-js-utils';
 
 export const DEFAULT_BIB_FILENAME = 'main.bib';
 const TEX_IMAGE_EXTENSIONS = ['.pdf', '.png', '.jpg', '.jpeg'];

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -151,7 +151,9 @@ export async function transformMdast(
   // Combine file-specific citation renderers with project renderers from bib files
   const fileCitationRenderer = combineCitationRenderers(cache, ...rendererFiles);
   // Kind needs to still be Article here even if jupytext, to handle outputs correctly
-  await transformOutputs(session, mdast, kind);
+  await transformOutputs(session, mdast, kind, imageWriteFolder, {
+    altOutputFolder: imageAltOutputFolder,
+  });
   transformCitations(log, mdast, fileCitationRenderer, references, file);
   await unified()
     .use(codePlugin, { lang: frontmatter?.kernelspec?.language })

--- a/packages/myst-cli/src/transforms/images.ts
+++ b/packages/myst-cli/src/transforms/images.ts
@@ -106,7 +106,7 @@ export async function downloadAndSaveImage(
   }
 }
 
-function resolveOutputPath(file: string, writeFolder: string, altOutputFolder?: string) {
+export function resolveOutputPath(file: string, writeFolder: string, altOutputFolder?: string) {
   if (altOutputFolder == null) {
     return path.join(writeFolder, file);
   }

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -3,14 +3,22 @@ import path from 'path';
 import type { GenericNode } from 'myst-common';
 import { selectAll } from 'unist-util-select';
 import type { IOutput } from '@jupyterlab/nbformat';
+import type { MinifiedMimePayload } from 'nbtx';
 import { extFromMimeType, minifyCellOutput, walkOutputs } from 'nbtx';
 import type { Root } from 'mdast';
 import { castSession } from '../session';
 import type { ISession } from '../session/types';
 import { KINDS } from './types';
 import { computeHash } from '../utils/computeHash';
+import { resolveOutputPath } from './images';
 
-export async function transformOutputs(session: ISession, mdast: Root, kind: KINDS) {
+export async function transformOutputs(
+  session: ISession,
+  mdast: Root,
+  kind: KINDS,
+  writeFolder: string,
+  opts?: { altOutputFolder?: string },
+) {
   const outputs = selectAll('output', mdast) as GenericNode[];
   const cache = castSession(session);
   if (outputs.length && kind === KINDS.Article) {
@@ -27,15 +35,14 @@ export async function transformOutputs(session: ISession, mdast: Root, kind: KIN
     walkOutputs(node.data, (obj) => {
       if (!obj.hash || !cache.$outputs[obj.hash]) return undefined;
       const [content, { contentType, encoding }] = cache.$outputs[obj.hash];
-      const folder = session.staticPath();
       const filename = `${obj.hash}${extFromMimeType(contentType)}`;
-      const destination = path.join(folder, filename);
+      const destination = path.join(writeFolder, filename);
 
       if (fs.existsSync(destination)) {
         session.log.debug(`Cached file found for notebook output: ${destination}`);
       } else {
         try {
-          if (!fs.existsSync(folder)) fs.mkdirSync(folder, { recursive: true });
+          if (!fs.existsSync(writeFolder)) fs.mkdirSync(writeFolder, { recursive: true });
           fs.writeFileSync(destination, content, { encoding: encoding as BufferEncoding });
           session.log.debug(`Notebook output successfully written: ${destination}`);
         } catch {
@@ -43,7 +50,44 @@ export async function transformOutputs(session: ISession, mdast: Root, kind: KIN
           return undefined;
         }
       }
-      obj.path = `/_static/${filename}`;
+      obj.path = resolveOutputPath(filename, writeFolder, opts?.altOutputFolder);
     });
+  });
+}
+
+/**
+ * Convert output nodes to image or code
+ *
+ * Note: this only supports mime payloads, not error or stream outputs.
+ * It also only supports minified images (i.e. images cannot be too small) or
+ * non-minified text (i.e. text cannot be too large).
+ */
+export function reduceOutputs(mdast: Root) {
+  const outputs = selectAll('output', mdast) as GenericNode[];
+  outputs.forEach((node) => {
+    let selectedOutput: MinifiedMimePayload | undefined;
+    walkOutputs(node.data, (obj) => {
+      if (selectedOutput || typeof obj.content_type !== 'string') return;
+      if (
+        (obj.content_type.startsWith('image/') && obj.path) ||
+        (obj.content_type.startsWith('text/') && obj.content)
+      ) {
+        selectedOutput = obj as MinifiedMimePayload;
+      }
+    });
+    if (!selectedOutput) return;
+    if (selectedOutput.content_type.startsWith('image/') && selectedOutput.path) {
+      node.type = 'image';
+      node.url = selectedOutput.path;
+      node.urlSource = selectedOutput.path;
+      delete node.data;
+      delete node.id;
+    }
+    if (selectedOutput.content_type.startsWith('text/') && selectedOutput.content) {
+      node.type = 'code';
+      node.value = selectedOutput.content;
+      delete node.data;
+      delete node.id;
+    }
   });
 }

--- a/packages/myst-to-docx/src/schema.ts
+++ b/packages/myst-to-docx/src/schema.ts
@@ -505,6 +505,10 @@ const citeGroup: Handler<{ type: 'citeGroup'; kind: 'narrative' | 'parenthetical
   }
 };
 
+const embed: Handler<{ type: 'embed' } & Parent> = (state, node) => {
+  state.renderChildren(node);
+};
+
 const mystComment: Handler<{ type: 'mystComment' } & Parent> = () => {
   // Do nothing!
   return;
@@ -559,4 +563,5 @@ export const defaultHandlers = {
   table,
   cite,
   citeGroup,
+  embed,
 };

--- a/packages/myst-to-tex/src/container.spec.ts
+++ b/packages/myst-to-tex/src/container.spec.ts
@@ -1,0 +1,24 @@
+import { CaptionKind, determineCaptionKind } from './container';
+
+describe('determineCaptionKind', () => {
+  it('iframe -> figure', () => {
+    const node = {
+      type: 'iframe',
+    };
+    expect(determineCaptionKind(node)).toEqual(CaptionKind.fig);
+  });
+  it('container[table] -> table', () => {
+    const node = {
+      type: 'container',
+      children: [{ type: 'table' }],
+    };
+    expect(determineCaptionKind(node)).toEqual(CaptionKind.table);
+  });
+  it('container[embed[block[text]]] -> null', () => {
+    const node = {
+      type: 'container',
+      children: [{ type: 'embed', children: [{ type: 'block', children: [{ type: 'text' }] }] }],
+    };
+    expect(determineCaptionKind(node)).toEqual(null);
+  });
+});

--- a/packages/myst-to-tex/src/container.ts
+++ b/packages/myst-to-tex/src/container.ts
@@ -1,4 +1,5 @@
-import type { Container, Image, Table, Code, Math } from 'myst-spec';
+import type { GenericNode } from 'myst-common';
+import type { Image, Table, Code, Math } from 'myst-spec';
 import { select } from 'unist-util-select';
 import { getColumnWidths } from './tables';
 import type { Handler } from './types';
@@ -26,16 +27,12 @@ function switchKind(node: Image | Table | Code | Math) {
   }
 }
 
-export function determineCaptionKind(
-  node: Container | Image | Table | Code | Math,
-): CaptionKind | null {
-  if (node.type !== 'container') return switchKind(node);
-  const childrenKinds: CaptionKind[] = [];
-  node.children.forEach((n) => {
-    const kind = switchKind(n as any);
-    if (kind) childrenKinds.push(kind);
+export function determineCaptionKind(node: GenericNode): CaptionKind | null {
+  let kind = switchKind(node as any);
+  node.children?.forEach((n) => {
+    if (!kind) kind = determineCaptionKind(n);
   });
-  return childrenKinds[0] ?? null;
+  return kind;
 }
 
 function nodeToCommand(node: Image | Table | Code | Math) {

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -236,6 +236,9 @@ const handlers: Record<string, Handler> = {
       state.write(`\\cite{${node.label}}`);
     }
   },
+  embed(node, state) {
+    state.renderChildren(node, true);
+  },
 };
 
 class TexSerializer implements ITexSerializer {


### PR DESCRIPTION
#143 added the ability to embed output images and other blocks from one page into another with `embed`, `image`, or `figure` directives. However, for static PDF/docx exports, we were only processing a single page, so references to content on other pages did not resolve.

Now, we process all files in a project even for single page exports. While `crossReference` links still don't work (since the target page doesn't exist), `embed` content now works (since it is pulled from the target page onto the exported page).

Furthermore, notebook `outputs`, which previously only worked in a web context, are now converted to static `images` or `code` for rendering in a static document. Rich HTML outputs still are not supported, but simple image/text outputs are.

![image](https://user-images.githubusercontent.com/9453731/214507279-334a9248-6b59-49c5-8dea-cf2f7c90e54b.png)
