### PR TITLE
📄 Render include node children during tex/docx export

### DIFF
--- a/.changeset/friendly-dodos-think.md
+++ b/.changeset/friendly-dodos-think.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Log vfile errors from myst-to-tex pipeline

--- a/.changeset/stupid-steaks-perform.md
+++ b/.changeset/stupid-steaks-perform.md
@@ -1,0 +1,6 @@
+---
+'myst-to-docx': patch
+'myst-to-tex': patch
+---
+
+Support include node in myst-to-docx and myst-to-tex

--- a/packages/myst-cli/src/build/tex/single.spec.ts
+++ b/packages/myst-cli/src/build/tex/single.spec.ts
@@ -1,10 +1,12 @@
 import type { Root } from 'mdast';
+import { Session } from '../../session';
 import { extractTexPart } from './single';
 
 describe('extractPart', () => {
   it('no tagged part returns undefined', async () => {
     expect(
       extractTexPart(
+        new Session(),
         { type: 'root', children: [{ type: 'text', value: 'untagged content' }] },
         { id: 'test_tag', required: true },
         {},
@@ -33,7 +35,7 @@ describe('extractPart', () => {
         },
       ],
     };
-    expect(extractTexPart(tree, { id: 'test_tag' }, {}, { myst: 'v1' })).toEqual({
+    expect(extractTexPart(new Session(), tree, { id: 'test_tag' }, {}, { myst: 'v1' })).toEqual({
       value: 'tagged content\n\nalso tagged content',
       imports: [],
       commands: {},
@@ -61,7 +63,13 @@ describe('extractPart', () => {
       ],
     };
     expect(
-      extractTexPart(tree, { id: 'test_tag', max_chars: 1000, max_words: 100 }, {}, { myst: 'v1' }),
+      extractTexPart(
+        new Session(),
+        tree,
+        { id: 'test_tag', max_chars: 1000, max_words: 100 },
+        {},
+        { myst: 'v1' },
+      ),
     ).toEqual({
       value: 'tagged content',
       imports: [],
@@ -79,7 +87,9 @@ describe('extractPart', () => {
         },
       ],
     };
-    expect(extractTexPart(tree, { id: 'test_tag', max_chars: 5 }, {}, { myst: 'v1' })).toEqual({
+    expect(
+      extractTexPart(new Session(), tree, { id: 'test_tag', max_chars: 5 }, {}, { myst: 'v1' }),
+    ).toEqual({
       value: 'tagged content',
       imports: [],
       commands: {},
@@ -96,7 +106,9 @@ describe('extractPart', () => {
         },
       ],
     };
-    expect(extractTexPart(tree, { id: 'test_tag', max_words: 1 }, {}, { myst: 'v1' })).toEqual({
+    expect(
+      extractTexPart(new Session(), tree, { id: 'test_tag', max_words: 1 }, {}, { myst: 'v1' }),
+    ).toEqual({
       value: 'tagged content',
       imports: [],
       commands: {},

--- a/packages/myst-to-docx/src/schema.ts
+++ b/packages/myst-to-docx/src/schema.ts
@@ -509,6 +509,10 @@ const embed: Handler<{ type: 'embed' } & Parent> = (state, node) => {
   state.renderChildren(node);
 };
 
+const include: Handler<{ type: 'include' } & Parent> = (state, node) => {
+  state.renderChildren(node);
+};
+
 const mystComment: Handler<{ type: 'mystComment' } & Parent> = () => {
   // Do nothing!
   return;
@@ -564,4 +568,5 @@ export const defaultHandlers = {
   cite,
   citeGroup,
   embed,
+  include,
 };

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -239,6 +239,9 @@ const handlers: Record<string, Handler> = {
   embed(node, state) {
     state.renderChildren(node, true);
   },
+  include(node, state) {
+    state.renderChildren(node, true);
+  },
 };
 
 class TexSerializer implements ITexSerializer {


### PR DESCRIPTION
This addresses #161 - When using the `include` directive, a new node of `type: include` is added to the document AST. However, this node type was simply ignored by `myst-to-tex` and `myst-to-docx`, so it's children disappeared 😱

This PR simply tells `myst-to-tex` and `myst-to-docx` to render the children of `include` nodes.