### PR TITLE
📤 Implicitly initialize project to resolve single file export cross references

### DIFF
--- a/packages/myst-cli/src/build/utils/getSingleFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getSingleFileContent.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { resolve } from 'path';
 import type { LinkTransformer } from 'myst-transforms';
 import type { ISession } from '../../session/types';
 import {
@@ -26,10 +26,10 @@ export async function getSingleFileContent(
     extraLinkTransformers?: LinkTransformer[];
   },
 ) {
-  file = path.resolve(file);
+  file = resolve(file);
   await processProject(
     session,
-    { path: projectPath },
+    { path: projectPath ?? resolve('.') },
     {
       writeFiles: false,
       imageWriteFolder,


### PR DESCRIPTION
Since we are now loading the whole project for single file exports, there are problems if no `project` config exists in a `myst.yml`:

![image](https://user-images.githubusercontent.com/9453731/215199186-9a3f8625-b980-4e89-b877-68173962f3eb.png)

With the change in this PR, there is a warning about no `project` but it still exports:

![image](https://user-images.githubusercontent.com/9453731/215199876-85d371c7-e132-4d67-8058-1ef6c6979e82.png)
