### PR TITLE
🐛 Validate subtitle & short_title on project/site

### DIFF
--- a/.changeset/mighty-olives-tie.md
+++ b/.changeset/mighty-olives-tie.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Validate short_title and subtitle on site and project

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -78,9 +78,9 @@ export type Export = {
 
 export type SiteFrontmatter = {
   title?: string;
+  description?: string;
   subtitle?: string;
   short_title?: string;
-  description?: string;
   authors?: Author[];
   venue?: Venue;
   github?: string;

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -38,6 +38,8 @@ import type {
 
 export const SITE_FRONTMATTER_KEYS = [
   'title',
+  'subtitle',
+  'short_title',
   'description',
   'authors',
   'venue',
@@ -62,8 +64,6 @@ export const PROJECT_FRONTMATTER_KEYS = [
   'exports',
 ].concat(SITE_FRONTMATTER_KEYS);
 export const PAGE_FRONTMATTER_KEYS = [
-  'subtitle',
-  'short_title',
   'kernelspec',
   'jupytext',
   'tags',
@@ -466,6 +466,15 @@ export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: Va
   if (defined(value.description)) {
     output.description = validateString(value.description, incrementOptions('description', opts));
   }
+  if (defined(value.short_title)) {
+    output.short_title = validateString(value.short_title, {
+      ...incrementOptions('short_title', opts),
+      maxLength: 40,
+    });
+  }
+  if (defined(value.subtitle)) {
+    output.subtitle = validateString(value.subtitle, incrementOptions('subtitle', opts));
+  }
   if (defined(value.authors)) {
     let authors = value.authors;
     // Turn a string into a list of strings, this will be transformed later
@@ -610,15 +619,6 @@ export function validateProjectFrontmatterKeys(
 
 export function validatePageFrontmatterKeys(value: Record<string, any>, opts: ValidationOptions) {
   const output: PageFrontmatter = validateProjectFrontmatterKeys(value, opts);
-  if (defined(value.subtitle)) {
-    output.subtitle = validateString(value.subtitle, incrementOptions('subtitle', opts));
-  }
-  if (defined(value.short_title)) {
-    output.short_title = validateString(value.short_title, {
-      ...incrementOptions('short_title', opts),
-      maxLength: 40,
-    });
-  }
   if (defined(value.kernelspec)) {
     output.kernelspec = validateKernelSpec(value.kernelspec, incrementOptions('kernelspec', opts));
   }


### PR DESCRIPTION
Support for validation to match the new types. subtitle and short_title are now available for the project and site.