### PR TITLE
💥 Reload project on toc change, new bib files

### DIFF
--- a/.changeset/wicked-mayflies-drum.md
+++ b/.changeset/wicked-mayflies-drum.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Reload project on toc/bib file changes during site watch

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -41,6 +41,7 @@ type ProcessOptions = {
   extraLinkTransformers?: LinkTransformer[];
   extraTransforms?: TransformFn[];
   defaultTemplate?: string;
+  reloadProject?: boolean;
 };
 
 export function changeFile(session: ISession, path: string, eventType: string) {
@@ -100,10 +101,14 @@ export async function addProjectReferencesToObjectsInv(
   return inv;
 }
 
-export async function loadProject(session: ISession, projectPath: string, writeToc = false) {
+export async function loadProject(
+  session: ISession,
+  projectPath: string,
+  opts?: { writeToc?: boolean; reloadProject?: boolean },
+) {
   const project = await loadProjectFromDisk(session, projectPath, {
-    writeToc,
     warnOnNoConfig: true,
+    ...opts,
   });
   // Load the citations first, or else they are loaded in each call below
   const pages = filterPages(project);
@@ -243,6 +248,7 @@ export async function processProject(
     watchMode,
     writeToc,
     writeFiles = true,
+    reloadProject,
   } = opts || {};
   if (!siteProject.path) {
     const slugSuffix = siteProject.slug ? `: ${siteProject.slug}` : '';
@@ -250,7 +256,10 @@ export async function processProject(
     if (siteProject.remote) log.error(`Remote path not supported${slugSuffix}`);
     throw Error('Unable to process project');
   }
-  const { project, pages } = await loadProject(session, siteProject.path, writeFiles && writeToc);
+  const { project, pages } = await loadProject(session, siteProject.path, {
+    writeToc: writeFiles && writeToc,
+    reloadProject,
+  });
   if (!watchMode) {
     await Promise.all([
       // Load all citations (.bib)

--- a/packages/myst-cli/src/project/load.ts
+++ b/packages/myst-cli/src/project/load.ts
@@ -27,11 +27,13 @@ import type { LocalProject, LocalProjectPage } from './types';
 export async function loadProjectFromDisk(
   session: ISession,
   path?: string,
-  opts?: { index?: string; writeToc?: boolean; warnOnNoConfig?: boolean },
+  opts?: { index?: string; writeToc?: boolean; warnOnNoConfig?: boolean; reloadProject?: boolean },
 ): Promise<LocalProject> {
   path = path || resolve('.');
-  const cachedProject = selectors.selectLocalProject(session.store.getState(), path);
-  if (cachedProject) return cachedProject;
+  if (!opts?.reloadProject) {
+    const cachedProject = selectors.selectLocalProject(session.store.getState(), path);
+    if (cachedProject) return cachedProject;
+  }
   const projectConfig = selectors.selectLocalProjectConfig(session.store.getState(), path);
   if (!projectConfig && opts?.warnOnNoConfig) {
     session.log.warn(


### PR DESCRIPTION
During site build, the project structure was never reloaded. This means changes to `_toc.yml` were not picked up, nor were new `bib` files.

This PR causes project to be reloaded in these two cases so changes to `_toc.yml` are reflected in the site structure and new `bib` files are consumed.

Resolves #157 