### PR TITLE
📤 Get text output working in exports

### DIFF
--- a/.changeset/dull-kings-boil.md
+++ b/.changeset/dull-kings-boil.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Modify how doi references are counted to make log messages slightly more correct

--- a/.changeset/eighty-mugs-care.md
+++ b/.changeset/eighty-mugs-care.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Allow file loading to specify maxCharacters to nbtx minification, enabling text output in exports

--- a/package-lock.json
+++ b/package-lock.json
@@ -12578,6 +12578,7 @@
         "node-fetch": "^3.2.10",
         "redux": "^4.2.0",
         "simple-validators": "^0.0.3",
+        "strip-ansi": "^7.0.1",
         "tex-to-myst": "^0.0.14",
         "unified": "^10.1.2",
         "unist-util-filter": "^4.0.0",
@@ -12632,6 +12633,17 @@
         "typescript": "^4.6.3"
       }
     },
+    "packages/myst-cli/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "packages/myst-cli/node_modules/chalk": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
@@ -12682,6 +12694,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "packages/myst-cli/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/myst-common": {
@@ -19107,6 +19133,7 @@
         "redux": "^4.2.0",
         "rimraf": "^3.0.2",
         "simple-validators": "^0.0.3",
+        "strip-ansi": "^7.0.1",
         "tex-to-myst": "^0.0.14",
         "ts-jest": "^28.0.7",
         "typescript": "latest",
@@ -19118,6 +19145,11 @@
         "ws": "^8.9.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+        },
         "chalk": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
@@ -19140,6 +19172,14 @@
             "data-uri-to-buffer": "^4.0.0",
             "fetch-blob": "^3.1.4",
             "formdata-polyfill": "^4.0.10"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "requires": {
+            "ansi-regex": "^6.0.1"
           }
         }
       }

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -86,6 +86,7 @@
     "node-fetch": "^3.2.10",
     "redux": "^4.2.0",
     "simple-validators": "^0.0.3",
+    "strip-ansi": "^7.0.1",
     "tex-to-myst": "^0.0.14",
     "unified": "^10.1.2",
     "unist-util-filter": "^4.0.0",

--- a/packages/myst-cli/src/build/utils/getSingleFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getSingleFileContent.ts
@@ -54,6 +54,6 @@ export async function getSingleFileContent(
   selectedFile = selectFile(session, file);
   if (!selectedFile) throw new Error(`Could not load file information for ${file}`);
   // Transform output nodes to images / text
-  reduceOutputs(selectedFile.mdast);
+  reduceOutputs(selectedFile.mdast, imageWriteFolder);
   return selectedFile;
 }

--- a/packages/myst-cli/src/build/utils/getSingleFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getSingleFileContent.ts
@@ -36,11 +36,12 @@ export async function getSingleFileContent(
       imageAltOutputFolder,
       imageExtensions,
       extraLinkTransformers,
+      minifyMaxCharacters: 0,
     },
   );
   let selectedFile = selectFile(session, file);
   if (!selectedFile) {
-    await loadFile(session, file);
+    await loadFile(session, file, undefined, { minifyMaxCharacters: 0 });
     // Collect bib files - myst-to-tex will need those, not 'references'
     await transformMdast(session, {
       file,
@@ -48,6 +49,7 @@ export async function getSingleFileContent(
       imageAltOutputFolder: imageAltOutputFolder ?? undefined,
       imageExtensions,
       projectPath,
+      minifyMaxCharacters: 0,
     });
     await postProcessMdast(session, { file, extraLinkTransformers });
   }

--- a/packages/myst-cli/src/process/file.ts
+++ b/packages/myst-cli/src/process/file.ts
@@ -27,6 +27,7 @@ export async function loadFile(
   session: ISession,
   file: string,
   extension?: '.md' | '.ipynb' | '.bib',
+  opts?: { minifyMaxCharacters?: number },
 ) {
   const toc = tic();
   session.store.dispatch(warnings.actions.clearWarnings({ file }));
@@ -50,7 +51,7 @@ export async function loadFile(
         const content = fs.readFileSync(file).toString();
         const { sha256, useCache } = checkCache(cache, content, file);
         if (useCache) break;
-        const mdast = await processNotebook(cache, file, content);
+        const mdast = await processNotebook(cache, file, content, opts);
         cache.$mdast[file] = {
           sha256,
           pre: { kind: KINDS.Notebook, file, mdast },

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -84,6 +84,7 @@ export async function transformMdast(
     imageExtensions?: string[];
     watchMode?: boolean;
     extraTransforms?: TransformFn[];
+    minifyMaxCharacters?: number;
   },
 ) {
   const {
@@ -96,6 +97,7 @@ export async function transformMdast(
     imageExtensions,
     extraTransforms,
     watchMode = false,
+    minifyMaxCharacters,
   } = opts;
   const toc = tic();
   const { store, log } = session;
@@ -153,6 +155,7 @@ export async function transformMdast(
   // Kind needs to still be Article here even if jupytext, to handle outputs correctly
   await transformOutputs(session, mdast, kind, imageWriteFolder, {
     altOutputFolder: imageAltOutputFolder,
+    minifyMaxCharacters,
   });
   transformCitations(log, mdast, fileCitationRenderer, references, file);
   await unified()

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -61,7 +61,7 @@ export async function processNotebook(
         const minified: MinifiedOutput[] = await minifyCellOutput(
           cell.outputs as IOutput[],
           cache.$outputs,
-          { computeHash },
+          { computeHash, maxCharacters: 0 },
         );
         const { myst, id } = createOutputDirective();
         outputMap[id] = minified;

--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -27,6 +27,7 @@ export async function processNotebook(
   session: ISession,
   file: string,
   content: string,
+  opts?: { minifyMaxCharacters?: number },
 ): Promise<Root> {
   const { log } = session;
   const { metadata, cells } = JSON.parse(content) as INotebookContent;
@@ -61,7 +62,7 @@ export async function processNotebook(
         const minified: MinifiedOutput[] = await minifyCellOutput(
           cell.outputs as IOutput[],
           cache.$outputs,
-          { computeHash, maxCharacters: 0 },
+          { computeHash, maxCharacters: opts?.minifyMaxCharacters },
         );
         const { myst, id } = createOutputDirective();
         outputMap[id] = minified;

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -42,6 +42,7 @@ type ProcessOptions = {
   extraTransforms?: TransformFn[];
   defaultTemplate?: string;
   reloadProject?: boolean;
+  minifyMaxCharacters?: number;
 };
 
 export function changeFile(session: ISession, path: string, eventType: string) {
@@ -249,6 +250,7 @@ export async function processProject(
     writeToc,
     writeFiles = true,
     reloadProject,
+    minifyMaxCharacters,
   } = opts || {};
   if (!siteProject.path) {
     const slugSuffix = siteProject.slug ? `: ${siteProject.slug}` : '';
@@ -265,7 +267,7 @@ export async function processProject(
       // Load all citations (.bib)
       ...project.bibliography.map((path) => loadFile(session, path, '.bib')),
       // Load all content (.md and .ipynb)
-      ...pages.map((page) => loadFile(session, page.file)),
+      ...pages.map((page) => loadFile(session, page.file, undefined, { minifyMaxCharacters })),
       // Load up all the intersphinx references
       loadIntersphinx(session, { projectPath: siteProject.path }) as Promise<any>,
     ]);

--- a/packages/myst-cli/src/transforms/outputs.ts
+++ b/packages/myst-cli/src/transforms/outputs.ts
@@ -17,7 +17,7 @@ export async function transformOutputs(
   mdast: Root,
   kind: KINDS,
   writeFolder: string,
-  opts?: { altOutputFolder?: string },
+  opts?: { altOutputFolder?: string; minifyMaxCharacters?: number },
 ) {
   const outputs = selectAll('output', mdast) as GenericNode[];
   const cache = castSession(session);
@@ -26,7 +26,7 @@ export async function transformOutputs(
       outputs.map(async (output) => {
         output.data = await minifyCellOutput(output.data as IOutput[], cache.$outputs, {
           computeHash,
-          maxCharacters: 0,
+          maxCharacters: opts?.minifyMaxCharacters,
         });
       }),
     );


### PR DESCRIPTION
- Text output now shows up in pdf/word exports
  - To get to this, we are now able to pass `maxCharacters` down to `nbtx` - for exports, we set this to `0`, so all outputs, no matter the size are temporarily minified to a separate file. Web outputs still keep the default `maxCharacters` to prevent excessive loading of tiny little minified files...
- Small tweak to doi counting so logs are slightly better during async loading...