### PR TITLE
💬 Add comment to default html-to-mdast handlers

### DIFF
--- a/.changeset/wet-seas-battle.md
+++ b/.changeset/wet-seas-battle.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Add comment to default html-to-mdast handlers

--- a/packages/myst-transforms/src/html.ts
+++ b/packages/myst-transforms/src/html.ts
@@ -30,6 +30,12 @@ const defaultHtmlToMdastOptions: Record<keyof HtmlTransformOptions, any> = {
     _brKeep(h: H, node: any) {
       return h(node, '_break');
     },
+    comment(h: any, node: any) {
+      // Prevents HTML comments from showing up as text in web
+      const result = h(node, 'comment');
+      (result as any).value = node.value;
+      return result;
+    },
   },
 };
 


### PR DESCRIPTION
This PR upstreams the functionality implemented here to be default in `myst-transforms`: https://github.com/executablebooks/jupyterlab-mystjs/pull/36