### PR TITLE
🎆 Update image conversion transform to handle EPS images

### DIFF
--- a/.changeset/sharp-cars-develop.md
+++ b/.changeset/sharp-cars-develop.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Update image conversion transform to handle EPS images


### PR DESCRIPTION
Currently this only converts EPS -> PNG. Other conversion requires inkscape which has a CLI bug loading EPS files: https://gitlab.com/inkscape/inkscape/-/issues/3524

There is a bunch of commented code we can revive it that issue gets resolved. We can also just delete the commented code and not worry about until EPS -> PNG becomes a problem...

I also tested some other PDF/SVG conversions and they seem to work as expected.