### PR TITLE
Improve admonitions to support GitHub and Quarto

### DIFF
--- a/.changeset/bright-buckets-kneel.md
+++ b/.changeset/bright-buckets-kneel.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Support github-style admonitions, add the `simple` class

--- a/.changeset/funny-actors-carry.md
+++ b/.changeset/funny-actors-carry.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'markdown-it-myst': patch
+---
+
+Allow directives to have spaces, and trim the name before passing it onto other directives

--- a/.changeset/loud-paws-learn.md
+++ b/.changeset/loud-paws-learn.md
@@ -1,0 +1,5 @@
+---
+'myst-spec-ext': patch
+---
+
+Add icon to Admonition spec

--- a/.changeset/tasty-mugs-love.md
+++ b/.changeset/tasty-mugs-love.md
@@ -1,0 +1,6 @@
+---
+'myst-directives': patch
+'myst-cli': patch
+---
+
+Allow admonitions to hide the icon

--- a/.changeset/thirty-cherries-brake.md
+++ b/.changeset/thirty-cherries-brake.md
@@ -1,0 +1,5 @@
+---
+'myst-directives': patch
+---
+
+Capture image alignment in figures

--- a/docs/admonitions.md
+++ b/docs/admonitions.md
@@ -1,47 +1,35 @@
 ---
-title: Callouts (admonitions)
+title: Callouts
 description: Callout blocks or admonitions, like "notes" or "hints" are outlined or shaded areas of a document to bring attention to particular information.
 thumbnail: ./thumbnails/admonitions.png
 ---
 
-To highlight a particular block of text that exists slightly apart from the narrative of your page you can use a number of directive kinds like `{note}` or `{warning}`.
-
-For example, try changing the following directive to a `{warning}`:
-
-```{myst}
-
-:::{note}
-Here is a note, try changing it to a `warning`!
-:::
-```
-
-The specification calls these kind of directives `admonition`, which are generally used through their named directives, like `{note}` or `{danger}`. Admonitions can have custom classes, icons and hide their children.
-
-(admonitions-list)=
-
-## Available admonitions
-
-There is one general `{admonition}` directive available, and a number of pre-styled admonitions:
-
-- `note`
-- `important`
-- `hint`
-- `seealso`
-- `tip`
-- `attention`
-- `caution`
-- `warning`
-- `danger`
-- `error`
-
-Try changing the directive type of the admonition below:
+Callouts, or "admonitions", highlight a particular block of text that exists slightly apart from the narrative of your page, such as a note or a warning.
+For example, try changing the following example of a `{tip}` admonition to a `{warning}`:
 
 ```{myst}
-
 :::{tip}
 Try changing `tip` to `warning`!
 :::
 ```
+
+In MyST we call these kind of directives admonitions, however, they are almost always used through their _named_ directives, like `{note}` or `{danger}`. Admonitions can be styled as `simple` or as a `dropdown`, and can optionally hide the icon. There are ten kinds[^docutils-admonitions] of admonitions available:
+
+```{list-table} Named admonitions that can be used as directives
+:name: admonitions-list
+* - 🔵 `note`
+  - 🟠 `attention`
+* - 🔵 `important`
+  - 🟠 `caution`
+* - 🟢 `hint`
+  - 🟠 `warning`
+* - 🟢 `seealso`
+  - 🔴 `danger`
+* - 🟢 `tip`
+  - 🔴 `error`
+```
+
+[^docutils-admonitions]: These admonitions are the same as those used in [docutils](https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions) and Sphinx.
 
 See below for a demo of each admonition in the default theme.
 
@@ -109,86 +97,90 @@ This is an error admonition
 
 `````
 
-## Admonition arguments
+## Admonition Titles
 
-The base `{admonition}` has a single argument, which is the **title**, you can use markdown in here!
+All admonitions have a single argument, which is the admonition title and can use markdown.
+If a title argument is not supplied the first node is used if it is a `heading` or a paragraph with fully bold text; otherwise the name of the directive is used (e.g. `seealso` becomes `See Also`; `note` becomes `Note`).
 
 ```{myst}
-
-:::{admonition} Admonition *title*
+:::{tip} Admonition _title_
 Here is an admonition!
 :::
 ```
 
-Note that all other admontions have no arguments, and as in other directives with no arguments content added in this spot will be prepended to the content body.
-
-% TODO: This should be improved in MyST, even though it is a constraint of sphinx
-
-::::{danger}
+:::::::{tip} Compatibility with GitHub
 :class: dropdown
-
-# Named admonitions don't have arguments
-
-All named admonitions (e.g. `{note}` or `{tip}`), have **no arguments**. Content on the first line will be prepended to the admonition body.
-
-Best practice is to put your body content on a new line. **This may change in future** to make it easier to create notes with custom titles.
+GitHub markdown transforms blockquotes that start with a bold `Note` or `Warning` into a simple admonition (see [GitHub](https://github.com/community/community/discussions/16925)). MyST also transforms these blockquotes into the appropriate admonitions with a `simple` class.
 
 ```{myst}
+> **Note** This is a note!
+```
 
-:::{note} Notes require **no** arguments,
-so content will be appended to the body.
+:::::::
+
+::::{tip} Compatibility with Pandoc & Quarto
+:class: dropdown
+In Quarto/Pandoc markdown admonitions are styled with special classes like `{.callout-note}` or `{callout-tip}`).
+If you are using JupyterBook or Sphinx documentation, use an `{admonition}` directive with the specific class, for example:
+
+```{myst}
+::: {.callout-tip}
+## Tip with Caption
+This is an example of a callout with a caption.
 :::
 ```
 
 ::::
 
-## Options
-
-**class**
-: CSS classes to add to your admonition, in addition to the default `admonition` class. The custom CSS class will be first.
-
-For example, you can try adding the name of an admonition to apply those styles.
-These classes in the default themes are lowercased without spaces (e.g. `seealso` or `error`).
-You can also add your own class names, and they will be available in HTML.
-To see an example, click the `HTML` tab in the below demo.
+::::{warning} Compatibility with Sphinx
+:class: dropdown
+In Sphinx, all named admonitions (e.g. `{note}` or `{tip}`), have **no arguments**.
+If you place content on the first line it will instead be prepended to the admonition body.
+If you are using JupyterBook or Sphinx documentation, use an `{admonition}` directive with the specific class, for example:
 
 ```{myst}
-
-:::{admonition} My title
-:class: tip
-My custom admonition that has a `tip` class applied!
+:::{admonition} The Title
+:class: hint
+This is the body.
 :::
 ```
 
-Note that if you provide conflicting class names, the first one in the {ref}`list above <admonitions-list>` will be used.
+::::
 
 (admonition-dropdown)=
 
 ## Admonition Dropdown
 
-You can also hide the body of your admonition blocks so that users must click the header to reveal the contents. This is helpful if you’d like to include some text that isn’t immediately visible to the user. To turn an admonition into a dropdown, add the `dropdown` class to them.
+To turn an admonition into a dropdown, add the `dropdown` class to them.
+Dropdown admonitions use the `<details>` HTML element (meaning they also will work without Javascript!),
+and they can be helpful when including text that shouldn't immediately visible to your readers.
 
 ```{myst}
-
-:::{note}
+:::{note} Click Me! 👈
 :class: dropdown
-This is initially hidden!
+👋 This could be a solution to a problem or contain other detailed explanations.
 :::
 ```
 
-You can use the `dropdown` class in conjunction with `{admonition}` directives to include your own titles and stylings. In the example below, we add both a `tip` and a `dropdown` class.
-
-```{myst}
-
-:::{admonition} Click here!
-:class: tip dropdown
-This is initially hidden!
-:::
-```
-
-```{seealso}
+:::{seealso} You can also use a `{dropdown}`
 :class: dropdown
-
-# Use "Dropdowns" for simple styles
 You can also use a `{dropdown}` directive, which provides a more compact writing experience and is simpler in the displayed style. See [](#dropdowns) for more information.
-```
+:::
+
+### Reference
+
+**Arguments** _(markdown)_
+: The `admonition` requires a single argument that is the title, parsed as markdown.
+
+**Options**
+: No options are required
+
+    class _(optional, string)_
+    : CSS classes to add to your admonition. Special classes include:
+      - `dropdown`: turns the admonition into a `<details>` html element
+      - `simple`: an admonition with "simple" styles
+      - the name of an admonition, the first admonition name encountered will be used
+    : Note that if you provide conflicting class names, the first one in the {ref}`list above <admonitions-list>` will be used.
+
+    icon _(optional, boolean)_
+    : setting icon to false will hide the icon

--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -1,11 +1,11 @@
 ---
 title: Blocks and comments
-description: Blocks provide structural divison in a MyST document using `+++`. These correspond, for example, to separate cells in a Jupyter Notebook. To add a comment, start your line with `%`.
+description: Blocks provide structural division in a MyST document using `+++`. These correspond, for example, to separate cells in a Jupyter Notebook. To add a comment, start your line with `%`.
 ---
 
 ## Blocks
 
-`Blocks` provide a structural divison of MyST documents using `+++`. These correspond, for example, to separate cells in a Jupyter Notebook. There can be optional metadata associated with the block, such as "tags", "parts" or other identifiers.
+`Blocks` provide a structural division of MyST documents using `+++`. These correspond, for example, to separate cells in a Jupyter Notebook. There can be optional metadata associated with the block, such as "tags", "parts" or other identifiers.
 
 ```{myst}
 +++ {"cell": "one"}
@@ -15,7 +15,7 @@ cell 2
 ```
 
 ```{tip}
-To identify a part of a document, like an abstract, use `+++ {"part": "abstract"}`, this will allow tools like the [](./creating-pdf-documents.md) to be created with the appropraite parts of information.
+To identify a part of a document, like an abstract, use `+++ {"part": "abstract"}`, this will allow tools like the [](./creating-pdf-documents.md) to be created with the appropriate parts of information.
 ```
 
 ## Comments
@@ -27,14 +27,12 @@ This next line won't render, but it is in the HTML and LaTeX!
 % Markdown comment line
 ```
 
-```{warning}
-# Comments only work at the begining of lines
+```{warning} Comments only work at the beginning of lines
 Note that a `%` is only a comment if it is at the beginning of a line, which is different than, for example, $\LaTeX$ where percent signs have to be escaped.
 ```
 
-````{note}
+````{note} Comments split paragraphs
 :class: dropdown
-# Comments split paragraphs
 Putting a comment between items will split any preceding elements. For example, a comment between two lines of text will be broken up into two paragraphs, resulting in a margin between them:
 
 ```{myst}

--- a/docs/code.md
+++ b/docs/code.md
@@ -45,7 +45,7 @@ from discretize import TensorMesh
 hx = [(1, 40)]
 hy = [(1, 40)]
 
-mesh = discretize.TensorMesh([hx, hy])
+mesh = TensorMesh([hx, hy])
 ```
 
 In the [](#my-program), we create a mesh for simulation using [SimPEG](https://discretize.simpeg.xyz/).

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -1,12 +1,12 @@
 ---
 title: Diagrams
-description: Include simple programatic mermaid diagrams in your documents.
+description: Include simple programmatic mermaid diagrams in your documents.
 thumbnail: ./thumbnails/diagrams.png
 ---
 
 It is possible to add [mermaid diagrams](https://mermaid-js.github.io/mermaid) using the `{mermaid}` directive, for example:
 
-````md
+````{myst}
 ```{mermaid}
 flowchart LR
   A[Jupyter Notebook] --> C
@@ -20,18 +20,3 @@ flowchart LR
   D <--> J[JATS]
 ```
 ````
-
-Will show:
-
-```{mermaid}
-flowchart LR
-  A[Jupyter Notebook] --> C
-  B[MyST Markdown] --> C
-  C(mystjs) --> D{AST}
-  D <--> E[LaTeX]
-  E --> F[PDF]
-  D --> G[Word]
-  D --> H[React]
-  D --> I[HTML]
-  D <--> J[JATS]
-```

--- a/docs/dropdowns-cards-and-tabs.md
+++ b/docs/dropdowns-cards-and-tabs.md
@@ -10,18 +10,12 @@ thumbnail: ./thumbnails/dropdowns-cards-and-tabs.png
 
 Dropdowns can be used to toggle content and show it only when a user clicks on the header panel. These use the standard HTML `<details>` element, meaning they also will work without Javascript. The dropdown can have a title, as the directive argument, and the open option can be used to initialise the dropdown in the open state.
 
-::::{dropdown} Open dropdown to see the syntax!
+```{myst}
+:::{dropdown} Dropdown Title
 :open:
-
-````markdown
-```{dropdown} Dropdown Title
-:open:
-
 Dropdown content
+:::
 ```
-````
-
-::::
 
 ```{seealso}
 :class: dropdown
@@ -37,7 +31,7 @@ To turn an admonition into a dropdown, add the option `:class: dropdown` to them
 Cards provide an easy way for you to content into a standard “header”, “body”, “footer” structure that has a similar alignment and visual style. It is useful for creating galleries or high-visibility collections of links and information.
 For example, a card with a header, title, body, and footer:
 
-````markdown
+````{myst}
 ```{card} Card title
 :header: The _Header_
 :footer: Footer
@@ -45,13 +39,6 @@ For example, a card with a header, title, body, and footer:
 Card content
 ```
 ````
-
-```{card} Card title
-:header: The _Header_
-:footer: Footer
-
-Card content
-```
 
 You can also add a `link` argument to the card, which will allow you to make the entire card clickable.
 
@@ -128,31 +115,18 @@ Execute notebook cells, store results, and insert outputs across pages.
 
 You can also produce tabbed content. This allows you to display a variety of tabbed content blocks that users can click on.
 
-`````markdown
-````{tab-set}
-```{tab-item} Tab 1
+```{myst}
+::::{tab-set}
+:::{tab-item} Tab 1
 :sync: tab1
 Tab one
-```
-```{tab-item} Tab 2
+:::
+:::{tab-item} Tab 2
 :sync: tab2
 Tab two
+:::
+::::
 ```
-````
-`````
-
-Creates:
-
-````{tab-set}
-```{tab-item} Tab 1
-:sync: tab1
-Tab one
-```
-```{tab-item} Tab 2
-:sync: tab2
-Tab two
-```
-````
 
 If you have multiple tabs with the same name, they will be synced!
 

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -37,6 +37,10 @@ underline
 smallcaps
 : Use the `sc` or `smallcaps` role, for example, `` {sc}`MyST` `` yields {sc}`MyST`
 
+```{myst}
+In {sc}`MyST`, you {del}`should never` {u}`underline` _text_.
+```
+
 ## Line Breaks
 
 To put a line break, without a paragraph, use a `\` followed by a new line. This corresponds to a `<br>` in HTML and `\\` in $\LaTeX$. For example, here is the [worlds shortest poem](wiki:Lines_on_the_Antiquity_of_Microbes):
@@ -68,15 +72,13 @@ For numbered lists, you can start following lines with any number, meaning they 
 
 For inline typography for subscript and superscript formatting, it is best practice to use a text-based representation over resorting to math exponents, i.e. `4$^{th}$`.
 This is required in some journal submissions, and using these roles ensure that the output in HTML and $\LaTeX$ is correct.
-The two roles for subscript and superscript are `sub` and `sup`, respectively.
+The two roles for subscript and superscript are `sub` and `sup`[^long-names], respectively.
 
 ```{myst}
 H{sub}`2`O, and 4{sup}`th` of July
 ```
 
-```{note}
-These two roles are also accessible through `subscript` and `superscript`.
-```
+[^long-names]: These two roles are also accessible through `subscript` and `superscript`.
 
 % For chemicals you can use the {chem}`H2O`
 

--- a/packages/markdown-it-myst/src/directives.ts
+++ b/packages/markdown-it-myst/src/directives.ts
@@ -12,10 +12,10 @@ const COLON_OPTION_REGEX = /^:(?<option>[^:\s]+?):(\s*(?<value>.*)){0,1}\s*$/;
 function replaceFences(state: StateCore): boolean {
   for (const token of state.tokens) {
     if (token.type === 'fence' || token.type === 'colon_fence') {
-      const match = token.info.match(/^\{([^\s}]+)\}\s*(.*)$/);
+      const match = token.info.match(/^\s*\{([^}]+)\}\s*(.*)$/);
       if (match) {
         token.type = 'directive';
-        token.info = match[1];
+        token.info = match[1].trim();
         token.meta = { arg: match[2] };
       }
     }

--- a/packages/markdown-it-myst/src/directives.ts
+++ b/packages/markdown-it-myst/src/directives.ts
@@ -12,7 +12,7 @@ const COLON_OPTION_REGEX = /^:(?<option>[^:\s]+?):(\s*(?<value>.*)){0,1}\s*$/;
 function replaceFences(state: StateCore): boolean {
   for (const token of state.tokens) {
     if (token.type === 'fence' || token.type === 'colon_fence') {
-      const match = token.info.match(/^\s*\{([^}]+)\}\s*(.*)$/);
+      const match = token.info.match(/^\s*\{\s*([^}\s]+)\s*\}\s*(.*)$/);
       if (match) {
         token.type = 'directive';
         token.info = match[1].trim();

--- a/packages/markdown-it-myst/tests/directives.spec.ts
+++ b/packages/markdown-it-myst/tests/directives.spec.ts
@@ -168,4 +168,11 @@ describe('parses directives', () => {
     expect(tokens[0].info).toEqual('abc');
     expect(tokens[2].info).toEqual('xyz');
   });
+  it('directives cannot have spaces', () => {
+    // We may change this in the future, if we add pandoc support
+    const mdit = MarkdownIt().use(plugin);
+    const tokens = mdit.parse('```` { ab c }\n\n``` { xyz }\n```\n\n````', {});
+    expect(tokens.map((t) => t.type)).toEqual(['fence']);
+    expect(tokens[0].info).toEqual(' { ab c }');
+  });
 });

--- a/packages/markdown-it-myst/tests/directives.spec.ts
+++ b/packages/markdown-it-myst/tests/directives.spec.ts
@@ -154,4 +154,18 @@ describe('parses directives', () => {
     expect(tokens[0].info).toEqual('abc');
     expect(tokens[2].info).toEqual('xyz');
   });
+  it('parses directives with spaces', () => {
+    const mdit = MarkdownIt().use(plugin);
+    const tokens = mdit.parse('````  { abc }\n\n``` { xyz }\n```\n\n````', {});
+    expect(tokens.map((t) => t.type)).toEqual([
+      'parsed_directive_open',
+      'directive_body_open',
+      'parsed_directive_open',
+      'parsed_directive_close',
+      'directive_body_close',
+      'parsed_directive_close',
+    ]);
+    expect(tokens[0].info).toEqual('abc');
+    expect(tokens[2].info).toEqual('xyz');
+  });
 });

--- a/packages/myst-directives/src/admonition.ts
+++ b/packages/myst-directives/src/admonition.ts
@@ -1,3 +1,4 @@
+import type { Admonition } from 'myst-spec-ext';
 import type { DirectiveSpec, DirectiveData, GenericNode } from 'myst-common';
 import { ParseTypesEnum } from 'myst-common';
 
@@ -31,6 +32,10 @@ export const admonitionDirective: DirectiveSpec = {
       type: ParseTypesEnum.string,
       // class_option: list of strings?
     },
+    icon: {
+      type: ParseTypesEnum.boolean,
+      // class_option: list of strings?
+    },
   },
   body: {
     type: ParseTypesEnum.parsed,
@@ -48,12 +53,18 @@ export const admonitionDirective: DirectiveSpec = {
     if (data.body) {
       children.push(...(data.body as GenericNode[]));
     }
-    const admonition = {
+    const admonition: Admonition = {
       type: 'admonition',
-      kind: data.name !== 'admonition' ? data.name.replace('.callout-', '') : undefined,
-      class: data.options?.class,
-      children,
+      kind:
+        data.name !== 'admonition'
+          ? (data.name.replace('.callout-', '') as Admonition['kind'])
+          : undefined,
+      class: data.options?.class as string,
+      children: children as any[],
     };
+    if (data.options?.icon === false) {
+      admonition.icon = false;
+    }
     return [admonition];
   },
 };

--- a/packages/myst-directives/src/figure.ts
+++ b/packages/myst-directives/src/figure.ts
@@ -58,6 +58,7 @@ export const figureDirective: DirectiveSpec = {
       alt: data.options?.alt as string,
       width: data.options?.width as string,
       height: data.options?.height as string,
+      align: data.options?.align as Image['align'],
     };
     const children: GenericNode[] = [img];
     if (data.body) {

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -5,6 +5,7 @@ import type {
   FootnoteDefinition as FND,
   Heading as SpecHeading,
   Image as SpecImage,
+  Admonition as SpecAdmonition,
 } from 'myst-spec';
 
 export type Delete = Parent & { type: 'delete' };
@@ -55,4 +56,8 @@ export type Heading = SpecHeading & {
 
 export type Image = SpecImage & {
   height?: string;
+};
+
+export type Admonition = SpecAdmonition & {
+  icon?: boolean;
 };

--- a/packages/myst-transforms/src/admonitions.spec.ts
+++ b/packages/myst-transforms/src/admonitions.spec.ts
@@ -1,0 +1,26 @@
+import { u } from 'unist-builder';
+import type { Root } from 'mdast';
+import { admonitionBlockquoteTransform, admonitionHeadersTransform } from './admonitions';
+
+describe('Test admonitionBlockquoteTransform', () => {
+  test('simple code block returns self', async () => {
+    const mdast = u('root', [
+      u('blockquote', [
+        u('paragraph', [
+          u('strong', [u('text', 'note')]),
+          u('text', 'We know what we are, but know not what we may be.'),
+        ]),
+      ]),
+    ]);
+    admonitionBlockquoteTransform(mdast as Root);
+    admonitionHeadersTransform(mdast as Root);
+    expect(mdast).toEqual(
+      u('root', [
+        u('admonition', { kind: 'note', class: 'simple' }, [
+          u('admonitionTitle', [u('text', 'Note')]),
+          u('paragraph', [u('text', 'We know what we are, but know not what we may be.')]),
+        ]),
+      ]),
+    );
+  });
+});

--- a/packages/myst-transforms/src/admonitions.ts
+++ b/packages/myst-transforms/src/admonitions.ts
@@ -1,13 +1,16 @@
 import type { Plugin } from 'unified';
 import type { Root } from 'mdast';
-import type { Admonition, AdmonitionTitle, FlowContent } from 'myst-spec';
+import type { Admonition, AdmonitionTitle, Blockquote, FlowContent } from 'myst-spec';
 import { selectAll } from 'unist-util-select';
 import { AdmonitionKind } from './types';
+import type { GenericNode } from 'myst-common';
 
 type Options = {
   /** Replace the admonition title with the first paragraph if it is all bold. */
   replaceAdmonitionTitles?: boolean;
 };
+
+const githubAdmonitionKinds = ['note', 'warning'];
 
 export function admonitionKindToTitle(kind: AdmonitionKind | string) {
   const transform: Record<string, string> = {
@@ -67,6 +70,41 @@ export function admonitionHeadersTransform(tree: Root, opts?: Options) {
   });
 }
 
+/**
+ * Visit all blockquote notes and add headers if necessary, support GitHub style admonitions
+ */
+export function admonitionBlockquoteTransform(tree: Root) {
+  const blockquote = selectAll('blockquote', tree) as Blockquote[];
+  blockquote.forEach((node: GenericNode) => {
+    if (
+      !node.children ||
+      node.children?.[0]?.type !== 'paragraph' ||
+      node.children[0].children?.[0]?.type !== 'strong'
+    ) {
+      return;
+    }
+    const strong = node.children[0].children[0];
+    if (strong.children?.[0].type !== 'text') return;
+    const kind = strong.children[0].value?.trim().toLowerCase() ?? '';
+    if (!githubAdmonitionKinds.includes(kind)) return;
+    node.type = 'admonition';
+    node.kind = kind;
+    node.class = node.class ? node.class + ' simple' : 'simple';
+    node.children[0].children.splice(0, 1); // Get rid of the strong node
+    node.children = [
+      {
+        type: 'admonitionTitle',
+        children: [{ type: 'text', value: admonitionKindToTitle(node.kind) }],
+      },
+      ...node.children,
+    ];
+  });
+}
+
 export const admonitionHeadersPlugin: Plugin<[Options?], Root, Root> = (opts) => (tree) => {
   admonitionHeadersTransform(tree, opts);
+};
+
+export const admonitionBlockquotePlugin: Plugin<[], Root, Root> = () => (tree) => {
+  admonitionBlockquoteTransform(tree);
 };

--- a/packages/myst-transforms/src/basic.ts
+++ b/packages/myst-transforms/src/basic.ts
@@ -4,7 +4,7 @@ import type { VFile } from 'vfile';
 import { liftMystDirectivesAndRolesTransform } from './liftMystDirectivesAndRoles';
 import { mystTargetsTransform, headingLabelTransform } from './targets';
 import { captionParagraphTransform } from './caption';
-import { admonitionHeadersTransform } from './admonitions';
+import { admonitionBlockquoteTransform, admonitionHeadersTransform } from './admonitions';
 import { blockMetadataTransform, blockNestingTransform } from './blocks';
 import { htmlIdsTransform } from './htmlIds';
 import { imageAltTextTransform } from './images';
@@ -23,6 +23,7 @@ export function basicTransformations(tree: Root, file: VFile) {
   mystTargetsTransform(tree);
   // Label headings after the targets-transform
   headingLabelTransform(tree);
+  admonitionBlockquoteTransform(tree); // Must be before header transforms
   admonitionHeadersTransform(tree);
   blockNestingTransform(tree);
   // Block metadata may contain labels/html_ids

--- a/packages/myst-transforms/src/index.ts
+++ b/packages/myst-transforms/src/index.ts
@@ -1,6 +1,8 @@
 export {
   admonitionHeadersPlugin,
   admonitionHeadersTransform,
+  admonitionBlockquotePlugin,
+  admonitionBlockquoteTransform,
   admonitionKindToTitle,
 } from './admonitions';
 export { AdmonitionKind } from './types';


### PR DESCRIPTION
This improves the documentation around the admonitions and adds explicit support for github and quarto-style admonitions.

Slightly nicer explainer I think:
![image](https://user-images.githubusercontent.com/913249/219566399-3fe4f2f4-f7fb-4a15-b5c5-bda24981c304.png)

Both of these work, but not yet in the demo (needs a release!)

![image](https://user-images.githubusercontent.com/913249/219566623-6c7594a0-60b9-4ba7-a085-cf6951aeb053.png)

