### PR TITLE
◻️ Allow whitespace around role name inside brackets

### DIFF
--- a/.changeset/hip-kids-collect.md
+++ b/.changeset/hip-kids-collect.md
@@ -1,0 +1,5 @@
+---
+'markdown-it-myst': patch
+---
+
+Allow whitespace around role name inside brackets

--- a/packages/markdown-it-myst/src/roles.ts
+++ b/packages/markdown-it-myst/src/roles.ts
@@ -50,7 +50,7 @@ try {
 } catch (error) {
   // Safari does not support negative look-behinds
   // This is a slightly down-graded variant, as it does not require a space.
-  _x = /^\{([a-zA-Z_\-+:]{1,36})\}(`+)(?!`)(.+?)\2(?!`)/;
+  _x = /^\{\s*([a-zA-Z_\-+:]{1,36})\s*\}(`+)(?!`)(.+?)\2(?!`)/;
 }
 const ROLE_PATTERN = _x;
 

--- a/packages/markdown-it-myst/src/roles.ts
+++ b/packages/markdown-it-myst/src/roles.ts
@@ -45,7 +45,8 @@ function roleRule(state: StateInline, silent: boolean): boolean {
 // TODO: support role with no value e.g. {role}``
 let _x: RegExp;
 try {
-  _x = new RegExp('^\\{([a-zA-Z_\\-+:]{1,36})\\}(`+)(?!`)(.+?)(?<!`)\\2(?!`)');
+  // This regex must be defined like this or Safari will crash
+  _x = new RegExp('^\\{\\s*([a-zA-Z_\\-+:]{1,36})\\s*\\}(`+)(?!`)(.+?)(?<!`)\\2(?!`)');
 } catch (error) {
   // Safari does not support negative look-behinds
   // This is a slightly down-graded variant, as it does not require a space.

--- a/packages/markdown-it-myst/tests/roles.spec.ts
+++ b/packages/markdown-it-myst/tests/roles.spec.ts
@@ -36,4 +36,26 @@ describe('parses roles', () => {
     expect(tokens[1].children?.[0].content).toEqual('# hello');
     expect(tokens[1].children?.[3].content).toEqual('hello');
   });
+  it('role with spaces around name parses', () => {
+    const mdit = MarkdownIt().use(plugin);
+    const tokens = mdit.parse('{  abc }`hello`', {});
+    expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
+    expect(tokens[1].children?.map((t) => t.type)).toEqual([
+      'parsed_role_open',
+      'role_body_open',
+      'inline',
+      'role_body_close',
+      'parsed_role_close',
+    ]);
+    expect(tokens[1].content).toEqual('{  abc }`hello`');
+    expect(tokens[1].children?.[0].info).toEqual('abc');
+    expect(tokens[1].children?.[0].content).toEqual('hello');
+    expect(tokens[1].children?.[2].content).toEqual('hello');
+  });
+  it('role with spaces inside name does not parse', () => {
+    const mdit = MarkdownIt().use(plugin);
+    const tokens = mdit.parse('{  ab c }`hello`', {});
+    expect(tokens.map((t) => t.type)).toEqual(['paragraph_open', 'inline', 'paragraph_close']);
+    expect(tokens[1].children?.map((t) => t.type)).toEqual(['text', 'code_inline']);
+  });
 });


### PR DESCRIPTION
Should be a small change, allowing whitespace around role names: `{ my_role }` - but it does change regex, which always feels a little risky.