### PR TITLE
#️⃣ tex-to-myst: Only insert figure number for latex \ref

### DIFF
--- a/.changeset/pink-cups-flow.md
+++ b/.changeset/pink-cups-flow.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Only insert figure number for latex \ref

--- a/packages/tex-to-myst/src/refs.ts
+++ b/packages/tex-to-myst/src/refs.ts
@@ -28,7 +28,7 @@ export const REF_HANDLERS: Record<string, Handler> = {
   macro_ref(node, state) {
     state.openParagraph();
     const label = texToText(getArguments(node, 'group'));
-    state.pushNode(u('crossReference', { label }));
+    state.pushNode(u('crossReference', { label }, [u('text', '%s')]));
   },
   macro_pageref(node, state) {
     state.openParagraph();

--- a/packages/tex-to-myst/tests/links.yml
+++ b/packages/tex-to-myst/tests/links.yml
@@ -55,3 +55,6 @@ cases:
                 - type: crossReference
                   identifier: mainlemma
                   label: mainlemma
+                  children:
+                    - type: text
+                      value: '%s'

--- a/packages/tex-to-myst/tests/refs.yml
+++ b/packages/tex-to-myst/tests/refs.yml
@@ -13,6 +13,9 @@ cases:
             - type: crossReference
               identifier: fig:test
               label: fig:Test
+              children:
+                - type: text
+                  value: '%s'
             - type: text
               value: ' on page '
             - type: crossReference
@@ -60,6 +63,9 @@ cases:
                 - type: crossReference
                   identifier: sec:greetings
                   label: sec:greetings
+                  children:
+                    - type: text
+                      value: '%s'
                 - type: text
                   value: '.'
   - title: equations


### PR DESCRIPTION
Parsing latex `Figure \ref{fig:...}` resulted in `Figure _Figure 1_`. Now it correctly inserts `Figure _1_`.

To insert `_Figure 1_` you can still use `\autoref` in the latex.