### PR TITLE
🐛 Fix typos in docs

### DIFF
--- a/docs/accessibility-and-performance.md
+++ b/docs/accessibility-and-performance.md
@@ -22,7 +22,7 @@ The real-world deployment of your site will depend on the infrastructure that yo
 
 ## Lighthouse Score
 
-Lighthouse is a tool included in Chrome that measures accessibility, performance, and search engine performance (see [lighthouse on GitHub](https://github.com/GoogleChrome/lighthouse)). Although not perfect, the tool does do a good job at highlighting issues with performace, search engine crawling, and accessibility. These scores indicate the real-world performance of a site as well as can effect search engine rankings.
+Lighthouse is a tool included in Chrome that measures accessibility, performance, and search engine performance (see [lighthouse on GitHub](https://github.com/GoogleChrome/lighthouse)). Although not perfect, the tool does do a good job at highlighting issues with performance, search engine crawling, and accessibility. These scores indicate the real-world performance of a site as well as can effect search engine rankings.
 
 ```{figure} ./images/lighthouse-2022_09_15.png
 :name: lighthouse

--- a/docs/background.md
+++ b/docs/background.md
@@ -7,7 +7,7 @@ This page discusses high-level questions about the MyST ecosystem, history of `m
 
 ## History of MyST and `mystjs`
 
-MyST (Markedly Structured Text) is a markup language that builds on standard markdown and is designed to create publication-quality documents, books, presentations, and websites written entirely in Markdown. The [ExecutableBooks] team recieved a grant from the [Sloan Foundation](https://sloan.org) to build, enhance, and promote a new path to document creation and publishing for next-generation scientific textbooks and lectures ([Grant #9231](https://sloan.org/grant-detail/9231)).
+MyST (Markedly Structured Text) is a markup language that builds on standard markdown and is designed to create publication-quality documents, books, presentations, and websites written entirely in Markdown. The [ExecutableBooks] team received a grant from the [Sloan Foundation](https://sloan.org) to build, enhance, and promote a new path to document creation and publishing for next-generation scientific textbooks and lectures ([Grant #9231](https://sloan.org/grant-detail/9231)).
 
 The initial use case driving the development and design of MyST has been [JupyterBook], which allows you to create educational online textbooks and tutorials with Jupyter Notebooks and narrative content written in MyST. The extensions and design of MyST is inspired by the [Sphinx] and [ReStructured Text](https://docutils.sourceforge.io/rst.html) (RST) ecosystems. Jupyter Book is considered a [distribution of Sphinx](myst:jupyterbook#explain/sphinx), and builds on the Sphinx and [Docutils] Python packages.
 

--- a/docs/code.md
+++ b/docs/code.md
@@ -13,7 +13,7 @@ For code execution, see the `{code-cell}` directive in the execution section of 
 ```
 
 You can include code in your documents using the standard markup syntax of ` ```language `,
-where language is the programing language for highlighting.
+where language is the programming language for highlighting.
 
 ````{myst}
 ```python
@@ -65,7 +65,7 @@ numbering:
 
 ## Numbering and Highlighting
 
-To add numbers and emphasis to lines, we are following the [sphinx](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block) `code-block` directive. You can use `linenos` which is a flag, with no value, and `emphasize-lines` with a comma-seperated list of line numbers to emphasize.
+To add numbers and emphasis to lines, we are following the [sphinx](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block) `code-block` directive. You can use `linenos` which is a flag, with no value, and `emphasize-lines` with a comma-separated list of line numbers to emphasize.
 
 ````{code-block} md
 :linenos:

--- a/docs/commonmark.md
+++ b/docs/commonmark.md
@@ -108,7 +108,7 @@ Section 2
 
 ```{seealso}
 Thematic breaks should not be confused with MyST [block syntax](./blocks.md),
-which is used to structurally seperate content.
+which is used to structurally separate content.
 ```
 
 ### Link Definitions
@@ -184,5 +184,5 @@ break
 ```
 
 ```{seealso}
-[](./typography.md) provides other roles for subscript, superscript, abbeviations, and other text formating.
+[](./typography.md) provides other roles for subscript, superscript, abbeviations, and other text formatting.
 ```

--- a/docs/creating-pdf-documents.md
+++ b/docs/creating-pdf-documents.md
@@ -40,7 +40,7 @@ To build the exports, use the `myst build` command, which will work with your [p
 myst build my-document.md --pdf
 ```
 
-Based on the `output` field in the export list in the [frontmatter](#export-frontmatter-pdf), the PDF and a log file will be written to `exports/my-document.pdf` and any associated log files. If the output file is a folder, the document name will be used with a `.pdf` or `.tex` extension, as appropriate. Any necessary auxilary files (e.g. for example `*.png` or `*.bib`) will be added to the base folder (`exports/` above).
+Based on the `output` field in the export list in the [frontmatter](#export-frontmatter-pdf), the PDF and a log file will be written to `exports/my-document.pdf` and any associated log files. If the output file is a folder, the document name will be used with a `.pdf` or `.tex` extension, as appropriate. Any necessary auxiliary files (e.g. for example `*.png` or `*.bib`) will be added to the base folder (`exports/` above).
 
 ## Rendering PDFs with $\LaTeX$
 

--- a/docs/creating-word-documents.md
+++ b/docs/creating-word-documents.md
@@ -57,7 +57,7 @@ Currently MyST export does not fully create math in Word's format, instead, $\La
 
 1. Select any equation and open the equation toolbar
 2. Click `LaTeX`
-3. In the conver dropdown, select "All - Professional"
+3. In the convert dropdown, select "All - Professional"
 4. Click convert
 
 ```{figure} ./images/convert-word-equations.png

--- a/docs/external-references.md
+++ b/docs/external-references.md
@@ -77,7 +77,7 @@ For example, `<myst:python#library/abc>` renders to:\
 and is made of a `protocol`, `project` and `target`.
 
 protocol
-: The protocol for this type of link is `myst:`, and is what selects for cross-project referening.
+: The protocol for this type of link is `myst:`, and is what selects for cross-project referencing.
 
 project
 : the `project` key above is "python" which is defined in your local [project configuration](#intersphinx-config) above.
@@ -136,7 +136,7 @@ To show different text you can use a similar technique to references:\
 
 ```{tip}
 :class: dropdown
-# Finding and formating the page title
+# Finding and formatting the page title
 To find the page title, browse Wikipedia and copy the last part of the URL, for example:\
 `Page_Title` in `https://wikipedia.org/wiki/Page_Title`. If you do not supply text for the link specifically, then the case of the link will be preserved and shown without the underscores.
 
@@ -149,7 +149,7 @@ Note that if the page title has spaces in it, simply replace them with underscor
 :class: dropdown
 # Different languages or wikis
 
-There are many different official and unofficial wikis that use the same [Wikimedia](wiki:Wikimedia_Foundation) technology, including subdomains in various langauges.
+There are many different official and unofficial wikis that use the same [Wikimedia](wiki:Wikimedia_Foundation) technology, including subdomains in various languages.
 
 Wikipedia links, like `https://fr.wikipedia.org/wiki/Croissant_(viennoiserie)` will work fine out of the box, and point to [](https://fr.wikipedia.org/wiki/Croissant_(viennoiserie)) with the popup still working!
 
@@ -160,7 +160,7 @@ Wikipedia links, like `https://fr.wikipedia.org/wiki/Croissant_(viennoiserie)` w
 
 ## GitHub Links
 
-MyST can directly integrate with links to GitHub to create hover-card information directly integrated into your MyST documents. For example, a link to the [linkTransforms](https://github.com/executablebooks/mystjs/blob/78d16ee1a/packages/myst-transforms/src/links/plugin.ts#L12-L28) plugin code shows a preview of the code. The code preview works for both mutliple line numbers and higlighting [single lines](https://github.com/executablebooks/mystjs/blob/78d16ee1a/packages/myst-transforms/src/links/plugin.ts#L30), which shows the surrounding ten lines, with the referenced line highlighted. If you reference the [full file](https://github.com/executablebooks/mystjs/blob/78d16ee1a/packages/myst-transforms/src/links/plugin.ts) then the first ten lines of the file are shown in the preview.
+MyST can directly integrate with links to GitHub to create hover-card information directly integrated into your MyST documents. For example, a link to the [linkTransforms](https://github.com/executablebooks/mystjs/blob/78d16ee1a/packages/myst-transforms/src/links/plugin.ts#L12-L28) plugin code shows a preview of the code. The code preview works for both multiple line numbers and highlighting [single lines](https://github.com/executablebooks/mystjs/blob/78d16ee1a/packages/myst-transforms/src/links/plugin.ts#L30), which shows the surrounding ten lines, with the referenced line highlighted. If you reference the [full file](https://github.com/executablebooks/mystjs/blob/78d16ee1a/packages/myst-transforms/src/links/plugin.ts) then the first ten lines of the file are shown in the preview.
 
 ````{important}
 :class: dropdown

--- a/docs/frontmatter.md
+++ b/docs/frontmatter.md
@@ -34,7 +34,7 @@ Frontmatter can be added to the first cell of a Jupyter Notebook, that cell shou
 ```{important}
 **Note**
 
-Remember to format the contents of the section as valid `yaml` even though when rendered, the cell will not look well formated in your notebook.
+Remember to format the contents of the section as valid `yaml` even though when rendered, the cell will not look well formatted in your notebook.
 ```
 
 ```{note}
@@ -214,7 +214,7 @@ This field can be set to a string value directly or to a License object.
 
 Available fields in the License object are `content` and `code` allowing licenses to be set separately for these two forms of content, as often different subsets of licenses are applicable to each. If you only wish to apply a single license to your page or project use the string form rather than an object.
 
-String values for licenses should be a valid “Identifier” string from the [SPDX License List](https://spdx.org/licenses/). Identifiers for well-known licenses are easily recognizable (e.g. `MIT` or `BSD`) and MyST will attempt to infer the specific identifier if an ambiguous license is specified (e.g. `GPL` will be interpreted as `GPL-3.0+` and a warning raised letting you know of this interpretation). Some commen licenses are:
+String values for licenses should be a valid “Identifier” string from the [SPDX License List](https://spdx.org/licenses/). Identifiers for well-known licenses are easily recognizable (e.g. `MIT` or `BSD`) and MyST will attempt to infer the specific identifier if an ambiguous license is specified (e.g. `GPL` will be interpreted as `GPL-3.0+` and a warning raised letting you know of this interpretation). Some common licenses are:
 
 ```{list-table}
 :header-rows: 1

--- a/docs/math.md
+++ b/docs/math.md
@@ -28,7 +28,7 @@ This math is a role, {math}`e=mc^2`, while this math is wrapped in dollar signs,
 The output of these is the same (which you can see by looking at the AST and $\LaTeX$ outputs in the demo above).
 Using a `math` role is much less likely to collide with your writing if it includes dollars (e.g. \$2.99).
 
-Ocassionally, dollar signs that you do not intend to wrap math need to be escaped.
+Occasionally, dollar signs that you do not intend to wrap math need to be escaped.
 These can be preceded by a backslash, that is `\$2.99`, and the `\` will not be displayed in your output.
 If using $\LaTeX$ as an output, these dollar-signs will also be properly escaped again!
 
@@ -100,7 +100,7 @@ The label implementation does not yet work for `sub-equations` and may not work 
 equation
 : basic equation environment, similar to a math directive or dollar-math
 
-multline
+multiline
 : variation equation, used for equations that don’t fit on a single line
 
 gather

--- a/docs/syntax-overview.md
+++ b/docs/syntax-overview.md
@@ -122,7 +122,7 @@ Here is an {abc}`unknown role`.
 ## Nesting content blocks in Markdown
 
 If you’d like to nest content blocks inside one another in Markdown (for example, to put a `{note}` inside of a `{margin}`), you may do so by adding extra backticks (`` ` ``)[^colon] to the outer-most block.
-For example, two [admonitions](./admonitions.md) nested in side of eachother:
+For example, two [admonitions](./admonitions.md) nested in side of each other:
 
 `````{myst}
 ````{important}

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -28,7 +28,7 @@ Standard inline formatting including bold, italic, code, as well as escaped symb
 ```
 
 strikethrough
-: Use the `del` or `strike` role, for example, `` {del}`text` `` yeilds {del}`text`
+: Use the `del` or `strike` role, for example, `` {del}`text` `` yields {del}`text`
 
 underline
 : Use the `u` or `underline` role, for example, `` {u}`text` `` yields {u}`text`
@@ -147,7 +147,7 @@ Term 3
 
 ## Footnotes
 
-Footnotes use the [pandoc specification](https://pandoc.org/MANUAL.html#footnotes). A footnote is labeled with `[^label]` and can then be any alpha-numeric string (no spaces), which is case-insensitive. This creates a link to the footnote definition, which is a line that starts with the same `[^label]: ` and then the text of the footnote.
+Footnotes use the [pandoc specification](https://pandoc.org/MANUAL.html#footnotes). A footnote is labeled with `[^label]` and can then be any alphanumeric string (no spaces), which is case-insensitive. This creates a link to the footnote definition, which is a line that starts with the same `[^label]: ` and then the text of the footnote.
 
 ```{myst}
 - A footnote reference[^myref]


### PR DESCRIPTION
Found via `typos --format brief` and `codespell docs`.