### PR TITLE
Small improvements to latex support

### DIFF
--- a/.changeset/cuddly-cows-live.md
+++ b/.changeset/cuddly-cows-live.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Warn on multiple titles in latex

--- a/.changeset/cuddly-turkeys-invite.md
+++ b/.changeset/cuddly-turkeys-invite.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Support multirow macro

--- a/.changeset/fresh-numbers-sit.md
+++ b/.changeset/fresh-numbers-sit.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Support latex renewcommand

--- a/.changeset/fuzzy-frogs-joke.md
+++ b/.changeset/fuzzy-frogs-joke.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Pass on latex commands adjustbox, makecell, textwidth, onecolumn

--- a/.changeset/ten-boats-give.md
+++ b/.changeset/ten-boats-give.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Implement multicolumn macro

--- a/packages/tex-to-myst/src/frontmatter.ts
+++ b/packages/tex-to-myst/src/frontmatter.ts
@@ -165,20 +165,30 @@ const FRONTMATTER_HANDLERS: Record<string, Handler> = {
     state.openNode('span');
     state.renderChildren(titleNode);
     state.closeParagraph();
-    // instead of closing, we are going to pop it off the stack
-    const renderedTitle = state.stack.pop();
-    state.data.frontmatter.title = childrenOrString(
-      getContentFromRenderedSpan(renderedTitle),
-    ) as any;
+    if (state.data.frontmatter.title) {
+      state.warn('Multiple titles defined in document', node);
+      state.closeNode();
+    } else {
+      // instead of closing, we are going to pop it off the stack
+      const renderedTitle = state.stack.pop();
+      state.data.frontmatter.title = childrenOrString(
+        getContentFromRenderedSpan(renderedTitle),
+      ) as any;
+    }
     if (shortTitleNode) {
       state.openNode('span');
       state.renderChildren(shortTitleNode);
       state.closeParagraph();
-      // instead of closing, we are going to pop it off the stack
-      const renderedShortTitle = state.stack.pop();
-      state.data.frontmatter.short_title = childrenOrString(
-        getContentFromRenderedSpan(renderedShortTitle),
-      ) as any;
+      if (state.data.frontmatter.title) {
+        state.warn('Multiple short titles defined in document', node);
+        state.closeNode();
+      } else {
+        // instead of closing, we are going to pop it off the stack
+        const renderedShortTitle = state.stack.pop();
+        state.data.frontmatter.short_title = childrenOrString(
+          getContentFromRenderedSpan(renderedShortTitle),
+        ) as any;
+      }
     }
   },
   macro_author(node, state) {

--- a/packages/tex-to-myst/src/frontmatter.ts
+++ b/packages/tex-to-myst/src/frontmatter.ts
@@ -179,7 +179,7 @@ const FRONTMATTER_HANDLERS: Record<string, Handler> = {
       state.openNode('span');
       state.renderChildren(shortTitleNode);
       state.closeParagraph();
-      if (state.data.frontmatter.title) {
+      if (state.data.frontmatter.short_title) {
         state.warn('Multiple short titles defined in document', node);
         state.closeNode();
       } else {

--- a/packages/tex-to-myst/src/frontmatter.ts
+++ b/packages/tex-to-myst/src/frontmatter.ts
@@ -131,6 +131,14 @@ const FRONTMATTER_HANDLERS: Record<string, Handler> = {
     }
     state.data.macros[name] = macro;
   },
+  macro_renewcommand(node, state) {
+    state.closeParagraph();
+    const [nameNode, macroNode] = getArguments(node, 'group');
+    getPositionExtents(macroNode);
+    const name = originalValue(state.tex, { position: getPositionExtents(nameNode) });
+    const macro = originalValue(state.tex, { position: getPositionExtents(macroNode) });
+    state.data.macros[name] = macro;
+  },
   macro_date(node, state) {
     state.closeParagraph();
     // No action for now

--- a/packages/tex-to-myst/src/misc.ts
+++ b/packages/tex-to-myst/src/misc.ts
@@ -61,4 +61,7 @@ export const MISC_HANDLERS: Record<string, Handler> = {
   // These are sometimes used in tables...
   macro_bgroup: pass,
   macro_egroup: pass,
+  // Used with adjustbox...
+  macro_textwidth: pass,
+  macro_onecolumn: pass,
 };

--- a/packages/tex-to-myst/src/misc.ts
+++ b/packages/tex-to-myst/src/misc.ts
@@ -64,4 +64,5 @@ export const MISC_HANDLERS: Record<string, Handler> = {
   // Used with adjustbox...
   macro_textwidth: pass,
   macro_onecolumn: pass,
+  macro_linewidth: pass,
 };

--- a/packages/tex-to-myst/src/tables.ts
+++ b/packages/tex-to-myst/src/tables.ts
@@ -112,4 +112,21 @@ export const TABLE_HANDLERS: Record<string, Handler> = {
   macro_makecell(node, state) {
     state.renderChildren(node);
   },
+  macro_multirow(node, state) {
+    // This macro is defined as:
+    //
+    // \multirow[vpos]{nrows}[bigstruts]{width}[vmove]{text}
+    //
+    // We take the first {}-bracket argument as nrows, if it is an integer
+    // and the last argument as content. All other arguments are ignored for now.
+    state.closeParagraph();
+    const nrowArg = node.args[0]?.openMark === '{' ? node.args[0] : node.args[1];
+    const rowspan = Number(nrowArg?.content?.[0]?.content);
+    const currentNode = state.stack[state.stack.length - 1];
+    if (currentNode?.type === 'tableCell' && Number.isInteger(rowspan)) {
+      currentNode.rowspan = rowspan;
+    }
+    state.renderChildren(node.args[node.args.length - 1]);
+    state.closeParagraph();
+  },
 };

--- a/packages/tex-to-myst/src/tables.ts
+++ b/packages/tex-to-myst/src/tables.ts
@@ -106,4 +106,10 @@ export const TABLE_HANDLERS: Record<string, Handler> = {
       state.closeNode();
     });
   },
+  env_adjustbox(node, state) {
+    state.renderChildren(node);
+  },
+  macro_makecell(node, state) {
+    state.renderChildren(node);
+  },
 };

--- a/packages/tex-to-myst/src/tables.ts
+++ b/packages/tex-to-myst/src/tables.ts
@@ -129,4 +129,18 @@ export const TABLE_HANDLERS: Record<string, Handler> = {
     state.renderChildren(node.args[node.args.length - 1]);
     state.closeParagraph();
   },
+  macro_multicolumn(node, state) {
+    // This macro is defined as:
+    //
+    // \multicolumn{ncols}{cols}{text}
+    state.closeParagraph();
+    const ncolArg = node.args[0];
+    const colspan = Number(ncolArg?.content?.[0]?.content);
+    const currentNode = state.stack[state.stack.length - 1];
+    if (currentNode?.type === 'tableCell' && Number.isInteger(colspan)) {
+      currentNode.colspan = colspan;
+    }
+    state.renderChildren(node.args[node.args.length - 1]);
+    state.closeParagraph();
+  },
 };

--- a/packages/tex-to-myst/src/tex.ts
+++ b/packages/tex-to-myst/src/tex.ts
@@ -18,9 +18,10 @@ function parseArgument(node: GenericNode, next: GenericNode): boolean {
     }
     const lastArg = node.args[node.args.length - 1];
     if (
-      ((next.content === '[' && (!lastArg || lastArg.openMark === '[')) ||
+      (mixed_arg_macros.includes(node.content) && next.content === '[') ||
+      (((next.content === '[' && (!lastArg || lastArg.openMark === '[')) ||
         (next.content === '(' && (!lastArg || lastArg.openMark === ')'))) &&
-      getArguments(node, 'group').length === 0
+        getArguments(node, 'group').length === 0)
     ) {
       node.args.push({
         type: 'argument',
@@ -49,6 +50,7 @@ function parseArgument(node: GenericNode, next: GenericNode): boolean {
   return false;
 }
 
+// Maximum number of arguments for each macro
 const macros: Record<string, number> = {
   citet: 1,
   citep: 1,
@@ -69,7 +71,7 @@ const macros: Record<string, number> = {
   framebox: 1,
   tnote: 1,
   arraystretch: 1,
-  multirow: 3,
+  multirow: 5,
   subfigure: 2,
   tabularx: 2,
   // These are character replacements:
@@ -93,6 +95,10 @@ const macros: Record<string, number> = {
   u: 1,
   v: 1,
 };
+
+// These macros allow a mix of {} and [] arguments, rather than only allowing
+// a single leading [] argument followed by {} arguments.
+const mixed_arg_macros = ['multirow'];
 
 /**
  * This fixes up some of the rendering that treats '[' as the first argument.

--- a/packages/tex-to-myst/src/tex.ts
+++ b/packages/tex-to-myst/src/tex.ts
@@ -72,6 +72,7 @@ const macros: Record<string, number> = {
   tnote: 1,
   arraystretch: 1,
   multirow: 5,
+  multicolumn: 3,
   subfigure: 2,
   tabularx: 2,
   // These are character replacements:

--- a/packages/tex-to-myst/tests/tables.yml
+++ b/packages/tex-to-myst/tests/tables.yml
@@ -201,3 +201,32 @@ cases:
                   children:
                     - type: text
                       value: Note this is freezing.
+  - title: multirow
+    tex: |-
+      \begin{tabular}{l c}
+        a & \multirow{2}{0.4\linewidth}[0cm]{b} \\ c &
+      \end{tabular}
+    tree:
+      type: root
+      children:
+        - type: table
+          children:
+            - type: tableRow
+              children:
+                - type: tableCell
+                  header: true
+                  children:
+                    - type: text
+                      value: a
+                - type: tableCell
+                  header: true
+                  rowspan: 2
+                  children:
+                    - type: text
+                      value: b
+            - type: tableRow
+              children:
+                - type: tableCell
+                  children:
+                    - type: text
+                      value: c

--- a/packages/tex-to-myst/tests/tables.yml
+++ b/packages/tex-to-myst/tests/tables.yml
@@ -230,3 +230,32 @@ cases:
                   children:
                     - type: text
                       value: c
+  - title: multicolumn
+    tex: |-
+      \begin{tabular}{l c}
+        a & b \\ \multicolumn{2}{0.4\linewidth}[0cm]{c} &
+      \end{tabular}
+    tree:
+      type: root
+      children:
+        - type: table
+          children:
+            - type: tableRow
+              children:
+                - type: tableCell
+                  header: true
+                  children:
+                    - type: text
+                      value: a
+                - type: tableCell
+                  header: true
+                  children:
+                    - type: text
+                      value: b
+            - type: tableRow
+              children:
+                - type: tableCell
+                  colspan: 2
+                  children:
+                    - type: text
+                      value: c


### PR DESCRIPTION
- basic implementation of `renewcommand` (same as `newcommand` except no warning on override)
- multiple `\title` values warn
- `adjustbox`, `makecell`, `textwidth`, `onecolum` all pass without warnings