### PR TITLE
👩‍🔬 Add cite nodes to myst-spec-ext

### DIFF
--- a/.changeset/serious-ducks-sip.md
+++ b/.changeset/serious-ducks-sip.md
@@ -1,0 +1,9 @@
+---
+'myst-cli': patch
+'myst-roles': patch
+'myst-spec-ext': patch
+'myst-to-docx': patch
+'tex-to-myst': patch
+---
+
+Add citation nodes to myst-spec-ext

--- a/package-lock.json
+++ b/package-lock.json
@@ -12660,6 +12660,7 @@
         "myst-frontmatter": "^0.0.9",
         "myst-parser": "^0.0.20",
         "myst-spec": "^0.0.4",
+        "myst-spec-ext": "^0.0.6",
         "myst-templates": "^0.1.10",
         "myst-to-docx": "^0.0.15",
         "myst-to-tex": "^0.0.18",
@@ -13064,7 +13065,8 @@
       "version": "0.0.20",
       "license": "MIT",
       "dependencies": {
-        "myst-common": "^0.0.14"
+        "myst-common": "^0.0.14",
+        "myst-spec-ext": "^0.0.6"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -13377,6 +13379,7 @@
         "@unified-latex/unified-latex": "^1.2.2",
         "myst-common": "^0.0.14",
         "myst-frontmatter": "^0.0.9",
+        "myst-spec-ext": "^0.0.6",
         "unist-util-select": "^4.0.0",
         "vfile-reporter": "^7.0.4"
       },
@@ -19472,6 +19475,7 @@
         "myst-frontmatter": "^0.0.9",
         "myst-parser": "^0.0.20",
         "myst-spec": "^0.0.4",
+        "myst-spec-ext": "^0.0.6",
         "myst-templates": "^0.1.10",
         "myst-to-docx": "^0.0.15",
         "myst-to-tex": "^0.0.18",
@@ -19779,6 +19783,7 @@
         "eslint-config-curvenote": "latest",
         "jest": "28.1.3",
         "myst-common": "^0.0.14",
+        "myst-spec-ext": "^0.0.6",
         "npm-run-all": "^4.1.5",
         "prettier": "latest",
         "rimraf": "^3.0.2",
@@ -21626,6 +21631,7 @@
         "jest": "^28.1.3",
         "myst-common": "^0.0.14",
         "myst-frontmatter": "^0.0.9",
+        "myst-spec-ext": "^0.0.6",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.6.1",
         "rimraf": "^3.0.2",

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -81,6 +81,7 @@
     "myst-frontmatter": "^0.0.9",
     "myst-parser": "^0.0.20",
     "myst-spec": "^0.0.4",
+    "myst-spec-ext": "^0.0.6",
     "myst-templates": "^0.1.10",
     "myst-to-docx": "^0.0.15",
     "myst-to-tex": "^0.0.18",

--- a/packages/myst-cli/src/transforms/citations.ts
+++ b/packages/myst-cli/src/transforms/citations.ts
@@ -3,24 +3,9 @@ import { InlineCite } from 'citation-js-utils';
 import type { Logger } from 'myst-cli-utils';
 import type { References } from 'myst-common';
 import type { StaticPhrasingContent, Parent } from 'myst-spec';
+import type { Cite, CiteKind, CiteGroup } from 'myst-spec-ext';
 import { selectAll } from 'unist-util-select';
 import type { Root } from 'mdast';
-
-export type CiteKind = 'narrative' | 'parenthetical';
-
-export type Cite = {
-  type: 'cite';
-  kind: CiteKind;
-  label: string;
-  children: StaticPhrasingContent[];
-  error?: boolean;
-};
-
-export type CiteGroup = {
-  type: 'citeGroup';
-  kind: CiteKind;
-  children: Cite[];
-};
 
 function pushCite(
   references: Pick<References, 'cite'>,

--- a/packages/myst-cli/src/transforms/dois.ts
+++ b/packages/myst-cli/src/transforms/dois.ts
@@ -9,7 +9,7 @@ import { tic } from 'myst-cli-utils';
 import type { Logger } from 'myst-cli-utils';
 import type { Root } from 'mdast';
 import { toText } from 'myst-common';
-import type { Cite } from './citations';
+import type { Cite } from 'myst-spec-ext';
 import type { SingleCitationRenderer } from './types';
 
 async function getDoiOrgBibtex(log: Logger, doiString: string): Promise<string | null> {

--- a/packages/myst-roles/package.json
+++ b/packages/myst-roles/package.json
@@ -38,7 +38,8 @@
     "url": "https://github.com/executablebooks/mystjs/issues"
   },
   "dependencies": {
-    "myst-common": "^0.0.14"
+    "myst-common": "^0.0.14",
+    "myst-spec-ext": "^0.0.6"
   },
   "devDependencies": {
     "@types/jest": "^28.1.6",

--- a/packages/myst-roles/src/cite.ts
+++ b/packages/myst-roles/src/cite.ts
@@ -1,3 +1,4 @@
+import type { CiteKind } from 'myst-spec-ext';
 import type { RoleSpec, RoleData, GenericNode } from 'myst-common';
 import { normalizeLabel, ParseTypesEnum } from 'myst-common';
 
@@ -22,10 +23,11 @@ export const citeRole: RoleSpec = {
     if (data.name === 'cite' && children.length === 1) {
       return children;
     }
+    const kind: CiteKind = data.name === 'cite:p' ? 'parenthetical' : 'narrative';
     return [
       {
         type: 'citeGroup',
-        kind: data.name === 'cite:p' ? 'parenthetical' : 'narrative',
+        kind,
         children,
       },
     ];

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   Parent,
+  StaticPhrasingContent,
   TableCell as SpecTableCell,
   FootnoteReference as FNR,
   FootnoteDefinition as FND,
@@ -60,4 +61,20 @@ export type Image = SpecImage & {
 
 export type Admonition = SpecAdmonition & {
   icon?: boolean;
+};
+
+export type CiteKind = 'narrative' | 'parenthetical';
+
+export type Cite = {
+  type: 'cite';
+  kind: CiteKind;
+  label: string;
+  children: StaticPhrasingContent[];
+  error?: boolean;
+};
+
+export type CiteGroup = {
+  type: 'citeGroup';
+  kind: CiteKind;
+  children: Cite[];
 };

--- a/packages/myst-to-docx/src/schema.ts
+++ b/packages/myst-to-docx/src/schema.ts
@@ -59,6 +59,7 @@ import type {
   CaptionNumber,
   FootnoteReference,
   FootnoteDefinition,
+  CiteKind,
 } from 'myst-spec-ext';
 import type { Handler, Mutable } from './types';
 import {
@@ -489,10 +490,7 @@ const cite: Handler<{ type: 'cite' } & Parent> = (state, node) => {
   state.renderChildren(node);
 };
 
-const citeGroup: Handler<{ type: 'citeGroup'; kind: 'narrative' | 'parenthetical' } & Parent> = (
-  state,
-  node,
-) => {
+const citeGroup: Handler<{ type: 'citeGroup'; kind: CiteKind } & Parent> = (state, node) => {
   if (node.kind === 'narrative') {
     state.renderChildren(node);
   } else {

--- a/packages/tex-to-myst/package.json
+++ b/packages/tex-to-myst/package.json
@@ -42,6 +42,7 @@
     "@unified-latex/unified-latex": "^1.2.2",
     "myst-common": "^0.0.14",
     "myst-frontmatter": "^0.0.9",
+    "myst-spec-ext": "^0.0.6",
     "unist-util-select": "^4.0.0",
     "vfile-reporter": "^7.0.4"
   },

--- a/packages/tex-to-myst/src/citations.ts
+++ b/packages/tex-to-myst/src/citations.ts
@@ -1,12 +1,13 @@
 import type { Handler, ITexParser } from './types';
 import { u } from 'unist-builder';
 import { getArguments, replaceTextValue, texToText } from './utils';
+import type { CiteKind } from 'myst-spec-ext';
 import type { GenericNode } from 'myst-common';
 
 function createCitation(
   state: ITexParser,
   node: GenericNode,
-  kind?: 'parenthetical' | 'narrative',
+  kind?: CiteKind,
   partial?: 'author' | 'year' | 'number',
 ) {
   state.openParagraph();


### PR DESCRIPTION
Refactors and brings the cite nodes into a more visible place.