### PR TITLE
🐛 Project frontmatter is now respected with tex files

### DIFF
--- a/.changeset/lovely-sheep-look.md
+++ b/.changeset/lovely-sheep-look.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Fix: project frontmatter is now respected with tex files

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -47,7 +47,15 @@ export function getPageFrontmatter(
       session.log.warn(`Validation: ${message}`);
     },
   });
+  const frontmatter = processPageFrontmatter(session, pageFrontmatter, path);
+  return frontmatter;
+}
 
+export function processPageFrontmatter(
+  session: ISession,
+  pageFrontmatter: PageFrontmatter,
+  path?: string,
+) {
   const state = session.store.getState();
   const siteFrontmatter = selectors.selectCurrentSiteConfig(state) ?? {};
   const projectFrontmatter = path ? selectors.selectLocalProjectConfig(state, path) ?? {} : {};

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -23,7 +23,7 @@ import {
 } from 'myst-transforms';
 import { unified } from 'unified';
 import { VFile } from 'vfile';
-import { getPageFrontmatter } from '../frontmatter';
+import { getPageFrontmatter, processPageFrontmatter } from '../frontmatter';
 import { selectors } from '../store';
 import { watch } from '../store/reducers';
 import type { ISession } from '../session/types';
@@ -108,7 +108,9 @@ export async function transformMdast(
   log.debug(`Processing "${file}"`);
   // Use structuredClone in future (available in node 17)
   const mdast = JSON.parse(JSON.stringify(mdastPre)) as Root;
-  const frontmatter = preFrontmatter ?? getPageFrontmatter(session, mdast, file, projectPath);
+  const frontmatter = preFrontmatter
+    ? processPageFrontmatter(session, preFrontmatter, projectPath)
+    : getPageFrontmatter(session, mdast, file, projectPath);
   const references: References = {
     cite: { order: [], data: {} },
     footnotes: {},


### PR DESCRIPTION
Tex page frontmatter is processed directly from the file itself early on, not from the mdast during post-processing (as we do for md pages). Since this followed a different path, the page frontmatter was never updated with project frontmatter for tex pages.

Now, the tex page frontmatter is updated with project frontmatter correctly.