### PR TITLE
🐛 Load an undefined YAML frontmatter

### DIFF
--- a/.changeset/thin-keys-rest.md
+++ b/.changeset/thin-keys-rest.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Works with undefined yaml block

--- a/packages/myst-transforms/src/frontmatter.spec.ts
+++ b/packages/myst-transforms/src/frontmatter.spec.ts
@@ -78,6 +78,22 @@ describe('getFrontmatter', () => {
     expect(tree).toEqual(input);
     expect(frontmatter).toEqual({ title: 'My Title' });
   });
+  it('empty yaml code block does not crash', () => {
+    // This is a block of `---\n---` at the start of a document
+    const input = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'yaml',
+          value: '',
+        },
+      ],
+    };
+    const { tree, frontmatter } = getFrontmatter(input as Root);
+    expect(tree).toEqual(input);
+    expect(frontmatter).toEqual({});
+  });
   it('yaml code block creates frontmatter, remove yaml', () => {
     const input = {
       type: 'root',

--- a/packages/myst-transforms/src/frontmatter.ts
+++ b/packages/myst-transforms/src/frontmatter.ts
@@ -21,7 +21,7 @@ export function getFrontmatter(
   let frontmatter: Record<string, any> = {};
   const firstIsYaml = firstNode?.type === 'code' && firstNode?.lang === 'yaml';
   if (firstIsYaml) {
-    frontmatter = yaml.load(firstNode.value) as Record<string, any>;
+    frontmatter = (yaml.load(firstNode.value) as Record<string, any>) || {};
     if (opts.removeYaml) (firstNode as any).type = '__delete__';
   }
   const nextNode = firstIsYaml ? secondNode : (firstNode as unknown as Heading);


### PR DESCRIPTION
Stops a bug from crashing the editor when frontmatter loads to be undefined.