### PR TITLE
Prevent rebuild loop

### DIFF
--- a/.changeset/early-carpets-sleep.md
+++ b/.changeset/early-carpets-sleep.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Prevent unwanted repeated site reload

--- a/.changeset/violet-shrimps-greet.md
+++ b/.changeset/violet-shrimps-greet.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Fix bug with undefined myst node associated with table macros

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -338,7 +338,9 @@ export async function processSite(session: ISession, opts?: ProcessOptions): Pro
   } catch (error) {
     session.log.debug(`\n\n${(error as Error)?.stack}\n\n`);
     session.log.error(
-      `Could not find configuration files, do you need to run ${chalk.bold('myst init')}?`,
+      `Error finding or reading configuration files, do you need to run ${chalk.bold(
+        'myst init',
+      )}?`,
     );
     process.exit(1);
   }

--- a/packages/myst-cli/src/store/reducers.ts
+++ b/packages/myst-cli/src/store/reducers.ts
@@ -100,10 +100,14 @@ export const watch = createSlice({
   initialState: { files: {}, reloading: false } as {
     files: Record<string, WatchedFile>;
     reloading: boolean;
+    reloadRequested: boolean;
   },
   reducers: {
-    markReloading(state, action: PayloadAction<{ reloading: boolean }>) {
-      state.reloading = action.payload.reloading;
+    markReloading(state, action: PayloadAction<boolean>) {
+      state.reloading = action.payload;
+    },
+    markReloadRequested(state, action: PayloadAction<boolean>) {
+      state.reloadRequested = action.payload;
     },
     markFileChanged(state, action: PayloadAction<{ path: string; sha256?: string }>) {
       const { path, sha256 = null } = action.payload;

--- a/packages/myst-cli/src/store/reducers.ts
+++ b/packages/myst-cli/src/store/reducers.ts
@@ -97,8 +97,14 @@ type WatchedFile = {
 
 export const watch = createSlice({
   name: 'watch',
-  initialState: { files: {} } as { files: Record<string, WatchedFile> },
+  initialState: { files: {}, reloading: false } as {
+    files: Record<string, WatchedFile>;
+    reloading: boolean;
+  },
   reducers: {
+    markReloading(state, action: PayloadAction<{ reloading: boolean }>) {
+      state.reloading = action.payload.reloading;
+    },
     markFileChanged(state, action: PayloadAction<{ path: string; sha256?: string }>) {
       const { path, sha256 = null } = action.payload;
       state.files[resolve(path)] = { ...state.files[resolve(path)], sha256 };

--- a/packages/myst-cli/src/store/selectors.ts
+++ b/packages/myst-cli/src/store/selectors.ts
@@ -63,7 +63,8 @@ export function selectLocalRawConfig(
 }
 
 export function selectReloadingState(state: RootState) {
-  return state.local.watch.reloading;
+  const { reloading, reloadRequested } = state.local.watch;
+  return { reloading, reloadRequested };
 }
 
 export function selectFileInfo(state: RootState, path: string) {

--- a/packages/myst-cli/src/store/selectors.ts
+++ b/packages/myst-cli/src/store/selectors.ts
@@ -62,6 +62,10 @@ export function selectLocalRawConfig(
   return state.local.config.rawConfigs[resolve(path)];
 }
 
+export function selectReloadingState(state: RootState) {
+  return state.local.watch.reloading;
+}
+
 export function selectFileInfo(state: RootState, path: string) {
   const {
     title,

--- a/packages/tex-to-myst/src/misc.ts
+++ b/packages/tex-to-myst/src/misc.ts
@@ -36,7 +36,7 @@ export const MISC_HANDLERS: Record<string, Handler> = {
   env_minipage(node, state) {
     state.closeParagraph();
     const top = state.top();
-    if (top.type === 'container' && top.kind === 'figure' && top.children?.length) {
+    if (top?.type === 'container' && top?.kind === 'figure' && top?.children?.length) {
       const topCopy = { ...top, children: [] };
       state.closeNode();
       state.openNode('container', topCopy);

--- a/packages/tex-to-myst/src/parser.ts
+++ b/packages/tex-to-myst/src/parser.ts
@@ -210,7 +210,7 @@ export class TexParser implements ITexParser {
   }
 
   openParagraph() {
-    const inPhrasing = phrasingTypes.has(this.top().type);
+    const inPhrasing = phrasingTypes.has(this.top()?.type);
     if (inPhrasing) return;
     this.openNode('paragraph');
   }
@@ -239,7 +239,7 @@ export class TexParser implements ITexParser {
 
   openBlock(attributes?: Record<string, any>) {
     this.closeParagraph();
-    const inPhrasing = phrasingTypes.has(this.top().type);
+    const inPhrasing = phrasingTypes.has(this.top()?.type);
     if (inPhrasing) return;
     this.openNode('block', attributes);
   }

--- a/packages/tex-to-myst/src/refs.ts
+++ b/packages/tex-to-myst/src/refs.ts
@@ -9,10 +9,10 @@ export const REF_HANDLERS: Record<string, Handler> = {
     const label = texToText(node);
     const parent = state.top();
     const last = parent?.children?.slice(-1)[0];
-    if (parent.type === 'container') {
+    if (parent?.type === 'container') {
       parent.label = label;
     } else if (
-      parent.type === 'caption' &&
+      parent?.type === 'caption' &&
       state.stack[state.stack.length - 2].type === 'container'
     ) {
       state.stack[state.stack.length - 2].label = label;

--- a/packages/tex-to-myst/src/tables.ts
+++ b/packages/tex-to-myst/src/tables.ts
@@ -127,7 +127,7 @@ export const TABLE_HANDLERS: Record<string, Handler> = {
       currentNode.rowspan = rowspan;
     }
     state.renderChildren(node.args[node.args.length - 1]);
-    state.closeNode();
+    state.closeParagraph();
   },
   macro_multicolumn(node, state) {
     // This macro is defined as:


### PR DESCRIPTION
This attempts to address https://github.com/executablebooks/mystjs/issues/266 (though the repeated site build is difficult to reliably reproduce, so we will see if this helps over time).

This PR starts by adding a simple check: `If we are currently reprocessing and a new reprocess is requested, do not reprocess again.`

However, so intentional changes are not lost, we need one more step: `If we are currently reprocessing and a new reprocess is requested, do not reprocess again right away, but *do* reprocess one more time when we are done.`

As we start considering more and more simultaneous reprocess requests, it gets harder to keep track of what exactly needs to be processed. For example, while reprocessing `file1`, if requests to reprocess `file2` and `file3` do we keep track of all of them...? To avoid this complexity, if a reprocess is requested, we simply reprocess _everything_ once the initial reprocess is complete.

We will see if this helps or just leads to more problems. As far as I can tell, there is no regression in the "happy-path" reprocessing behaviour. 😅