### PR TITLE
docs: add warning about spec

### DIFF
--- a/docs/cross-references.md
+++ b/docs/cross-references.md
@@ -171,6 +171,12 @@ See [](#my-math-label) for an equation!
 
 `````{tip}
 # Labelling dollar math
+
+
+````{warning}
+The following syntax for labelling dollar-math equations is in `beta`, as it is not yet described by the [MyST Specification](https://myst-spec.readthedocs.io/en/latest/index.html). As such, it may change in the future.
+````
+
 You can also use the dollar-math label, which is included in after an equation with `$$ (label)`.\
 This can even all be on a single line!
 ````{myst}
@@ -188,7 +194,7 @@ See [eq. %s](#my-math-label)!
 ## Notebook Cell Targets
 
 :::{warning}
-The following syntax for cross-referencing notebook cells is in `beta` and may change in the future.
+The following syntax for cross-referencing notebook cells is in `beta`, as it is not yet described by the [MyST Specification](https://myst-spec.readthedocs.io/en/latest/index.html). As such, it may change in the future.
 :::
 
 You can label notebook cells using a comment at the top of the cell, using a `#| label:` syntax, or have this added directly in the notebook metadata for the cell.

--- a/docs/cross-references.md
+++ b/docs/cross-references.md
@@ -168,7 +168,6 @@ e=mc^2
 
 See [](#my-math-label) for an equation!
 ````
-`````
 
 % Internal/external links
 % Checking for missing references, link to another place.

--- a/docs/cross-references.md
+++ b/docs/cross-references.md
@@ -168,22 +168,6 @@ e=mc^2
 
 See [](#my-math-label) for an equation!
 ````
-
-`````{tip}
-# Labelling dollar math
-
-
-````{warning}
-The following syntax for labelling dollar-math equations is in `beta`, as it is not yet described by the [MyST Specification](https://myst-spec.readthedocs.io/en/latest/index.html). As such, it may change in the future.
-````
-
-You can also use the dollar-math label, which is included in after an equation with `$$ (label)`.\
-This can even all be on a single line!
-````{myst}
-$$ e=mc^2 $$ (my-math-label)
-
-See [eq. %s](#my-math-label)!
-````
 `````
 
 % Internal/external links
@@ -194,7 +178,7 @@ See [eq. %s](#my-math-label)!
 ## Notebook Cell Targets
 
 :::{warning}
-The following syntax for cross-referencing notebook cells is in `beta`, as it is not yet described by the [MyST Specification](https://myst-spec.readthedocs.io/en/latest/index.html). As such, it may change in the future.
+The following syntax for cross-referencing notebook cells is in `beta`, as it is not yet described by the [MyST Specification](https://myst-tools.org/docs/spec/). As such, it may change in the future.
 :::
 
 You can label notebook cells using a comment at the top of the cell, using a `#| label:` syntax, or have this added directly in the notebook metadata for the cell.

--- a/docs/math.md
+++ b/docs/math.md
@@ -56,18 +56,19 @@ See [](#my-equation) for more information!
 ### Dollar math equations
 
 You can also create equations by wrapping content with two dollar signs (`$$`).
-In this syntax, you can follow the equation with a label in brackets `(label)`.
+In this syntax, you can use the `\label{label-name}` command to add a label.
 This can be quite convenient if your equations are small, the entire syntax can fit on a single line.
 
 ```{myst}
 $$
+\label{maxwell}
 \begin{aligned}
 \nabla \times \vec{e}+\frac{\partial \vec{b}}{\partial t}&=0 \\
 \nabla \times \vec{h}-\vec{j}&=\vec{s}\_{e}
 \end{aligned}
-$$ (maxwell)
+$$
 
-$$ Ax=b $$ (one-liner)
+$$ \label{one-liner} Ax=b $$
 
 See [](#maxwell) for enlightenment and [](#one-liner) to do things on one line!
 ```
@@ -137,8 +138,7 @@ There are a few different ways to reference equations, with more details in [](.
 
 The examples above all show how to label an equation in the interactive demos.
 With a directive, you can use the `label` option;
-with dollar-math, follow the closing `$$` with a space and a `(label)`; and
-in AMS math you can use the `\label{}` syntax that is native to $\LaTeX$.
+with dollar-math and AMS math, you can use the `\label{}` syntax that is native to $\LaTeX$.
 
 For example, a directive can be labelled as follows:
 


### PR DESCRIPTION
This PR starts to add a few admonitions that indicate where syntax is not in the MyST spec. I think the idea here would be that over time we make MEPs to introduce this syntax, and we gradually remove the warnings :)

Thoughts?