### PR TITLE
🔧 Write only 'myst: v1' not 'jtex: v1' in template.yml

### DIFF
--- a/.changeset/nasty-mayflies-accept.md
+++ b/.changeset/nasty-mayflies-accept.md
@@ -1,0 +1,5 @@
+---
+'jtex': patch
+---
+
+Write only 'myst: v1' not 'jtex: v1' in template.tex on 'jtex check --fix'

--- a/packages/jtex/src/cli/check.ts
+++ b/packages/jtex/src/cli/check.ts
@@ -335,7 +335,7 @@ export function checkTemplate(session: ISession, path: string, opts?: { fix?: bo
       ?.reduce((a, b) => a || b, false) ?? true;
 
   if (opts?.fix) {
-    configYaml.jtex = 'v1';
+    configYaml.myst = 'v1';
     if (!configYaml.doc) {
       configYaml.doc = extraDocOptions;
     } else {


### PR DESCRIPTION
When using `jtex check --fix` both `myst: v1` and `jtex: v1` were written to `template.yml`. We are moving to only use `myst: v1` and not write `jtex: v1` since not all templates are for `tex` ("jtex" on a docx template is maybe confusing).