### PR TITLE
🏗 Stop hoisting deep headings into frontmatter title

### DIFF
--- a/packages/myst-transforms/src/frontmatter.spec.ts
+++ b/packages/myst-transforms/src/frontmatter.spec.ts
@@ -283,43 +283,6 @@ describe('getFrontmatter', () => {
     });
     expect(frontmatter).toEqual({ title: 'My Title' });
   });
-  it('title is extracted from any heading if not in frontmatter', () => {
-    const input = {
-      type: 'root',
-      children: [
-        {
-          type: 'code',
-          lang: 'yaml',
-          value: 'subtitle: My Subtitle',
-        },
-        {
-          type: 'text',
-          value: 'hello',
-        },
-        {
-          type: 'text',
-          value: 'hello',
-        },
-        {
-          type: 'heading',
-          depth: 5,
-          children: [
-            {
-              type: 'text',
-              value: 'Small Title',
-            },
-          ],
-        },
-        {
-          type: 'text',
-          value: 'hello',
-        },
-      ],
-    };
-    const { tree, frontmatter } = getFrontmatter(input as Root, {});
-    expect(tree).toEqual(input);
-    expect(frontmatter).toEqual({ title: 'Small Title', subtitle: 'My Subtitle' });
-  });
   it('yaml code block creates frontmatter, nested in block', () => {
     const input = {
       type: 'root',

--- a/packages/myst-transforms/src/frontmatter.ts
+++ b/packages/myst-transforms/src/frontmatter.ts
@@ -36,13 +36,6 @@ export function getFrontmatter(
       if (opts.removeHeading) (nextNode as any).type = '__delete__';
     }
   }
-  if (!frontmatter.title) {
-    const heading = select('heading', tree) as Heading;
-    if (heading) {
-      frontmatter.title = toText(heading.children);
-      if (opts.removeHeading) (heading as any).type = '__delete__';
-    }
-  }
   if (opts.removeHeading || opts.removeYaml) {
     // Handles deleting the block if it is the only element in the block
     const possibleNull = remove(tree, '__delete__');


### PR DESCRIPTION
Fixes #281 maybe?

@rowanc1 I have no idea if someone needs this behavior. Obviously it could be controlled by a switch. For me it seems wrong to dig beyond the first H1 though.
