### PR TITLE
💱 Escape basic characters in latex href

### DIFF
--- a/.changeset/lucky-numbers-brake.md
+++ b/.changeset/lucky-numbers-brake.md
@@ -1,0 +1,5 @@
+---
+'myst-to-tex': patch
+---
+
+Escape basic characters in latex href

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -6,7 +6,7 @@ import { fileError, toText } from 'myst-common';
 import { captionHandler, containerHandler } from './container';
 import { renderNodeToLatex } from './tables';
 import type { Handler, ITexSerializer, LatexResult, Options, StateData } from './types';
-import { getLatexImageWidth, stringToLatexMath, stringToLatexText } from './utils';
+import { getLatexImageWidth, hrefToLatexText, stringToLatexMath, stringToLatexText } from './utils';
 import MATH_HANDLERS from './math';
 
 export type { LatexResult } from './types';
@@ -165,12 +165,16 @@ const handlers: Record<string, Handler> = {
     const href = node.url;
     if (node.children[0]?.value === href) {
       // URL is the same
-      state.write(`\\url{${href}}`);
+      state.write('\\url{');
+      state.write(hrefToLatexText(href));
+      state.write('}');
       return;
     }
-    state.write(`\\href{${href}}{`);
+    state.write('\\href{');
+    state.write(hrefToLatexText(href));
+    state.write('}{');
     state.renderChildren(node, true);
-    state.write(`}`);
+    state.write('}');
   },
   admonition(node, state) {
     state.usePackages('framed');

--- a/packages/myst-to-tex/src/utils.ts
+++ b/packages/myst-to-tex/src/utils.ts
@@ -10,7 +10,7 @@ const BACKSLASH_SPACE = '💥🎯BACKSLASHSPACE🎯💥';
 const BACKSLASH = '💥🎯BACKSLASH🎯💥';
 const TILDE = '💥🎯TILDE🎯💥';
 
-const textOnlyReplacements: Record<string, string> = {
+const hrefOnlyReplacements: Record<string, string> = {
   // Not allowed characters
   // Latex escaped characters are: \ & % $ # _ { } ~ ^
   '&': '\\&',
@@ -21,6 +21,10 @@ const textOnlyReplacements: Record<string, string> = {
   '{': '\\{',
   '}': '\\}',
   '^': '\\^',
+};
+
+const textOnlyReplacements: Record<string, string> = {
+  ...hrefOnlyReplacements,
   // quotes
   '’': "'",
   '‘': '`',
@@ -146,6 +150,26 @@ const mathReplacements: Record<string, string> = {
 };
 
 type SimpleTokens = { kind: 'math' | 'text'; text: string };
+
+export function hrefToLatexText(text: string) {
+  const replacedArray: SimpleTokens[] = Array(...(text ?? '')).map((char) => {
+    if (hrefOnlyReplacements[char]) return { kind: 'text', text: hrefOnlyReplacements[char] };
+    return { kind: 'text', text: char };
+  });
+
+  const replaced = replacedArray
+    .reduce((arr, next) => {
+      const prev = arr.slice(-1)[0];
+      if (prev?.kind === next.kind) prev.text += next.text;
+      else arr.push(next);
+      return arr;
+    }, [] as SimpleTokens[])
+    .reduce((s, next) => {
+      return s + next.text;
+    }, '');
+
+  return replaced;
+}
 
 export function stringToLatexText(text: string) {
   const escaped = (text ?? '')

--- a/packages/myst-to-tex/tests/basic.yml
+++ b/packages/myst-to-tex/tests/basic.yml
@@ -242,3 +242,18 @@ cases:
       \bottomrule
       \end{tabular}
       \end{table}
+  - title: href
+    mdast:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: 'my link: '
+            - type: link
+              url: https://example.com#^my_example
+              children:
+                - type: text
+                  value: my-example
+    latex: |-
+      my link: \href{https://example.com\#\^my\_example}{my-example}


### PR DESCRIPTION
This attempts to address #297 by escaping some special characters in latex hrefs.

I only escape basic latex characters; we don't want to accidentally replace a character with a latex macro. It is likely not perfect, but common characters like `#` and `_` are now no problem.