### PR TITLE
✅ Parse tasklists to an AST

### DIFF
--- a/.changeset/happy-hornets-impress.md
+++ b/.changeset/happy-hornets-impress.md
@@ -1,0 +1,5 @@
+---
+'myst-parser': patch
+---
+
+Update readme example

--- a/.changeset/hot-chicken-sniff.md
+++ b/.changeset/hot-chicken-sniff.md
@@ -1,0 +1,6 @@
+---
+'myst-parser': patch
+'myst-spec-ext': patch
+---
+
+Improve parsing of tasklists for mdast

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -68,6 +68,15 @@ You can use bullet points and numbered lists as you would in standard markdown. 
 
 For numbered lists, you can start following lines with any number, meaning they don't have to be in numerical order, and this will not change the rendered output. The exception is the first number, which if it is not `1.` this will change the start number of the list.
 
+## Task Lists
+
+You can use GitHub Flavoured Markdown to create task lists, these may be read only or editable depending on the use case or the theme used.
+
+```{myst}
+- [x] Create a community around MyST
+- [ ] Revolutionize technical communication
+```
+
 ## Subscript & Superscript
 
 For inline typography for subscript and superscript formatting, it is best practice to use a text-based representation over resorting to math exponents, i.e. `4$^{th}$`.

--- a/packages/myst-parser/tests/tasklists.spec.ts
+++ b/packages/myst-parser/tests/tasklists.spec.ts
@@ -1,0 +1,22 @@
+import type { List } from 'myst-spec';
+import type { ListItem } from 'myst-spec-ext';
+import { mystParse } from '../src';
+
+describe('Parses GFM Tasklists', () => {
+  test('Parse tasklist', () => {
+    const mdast = mystParse(`- [ ] task 1\n- [x] task 2\n - not a task`);
+    expect(mdast.children[0].type).toBe('list');
+    const task1 = (mdast.children[0] as List).children[0] as ListItem;
+    const task2 = (mdast.children[0] as List).children[1] as ListItem;
+    const task3 = (mdast.children[0] as List).children[2] as ListItem;
+    expect(task1.type).toBe('listItem');
+    expect(task1.checked).toBe(false);
+    expect((task1.children[0] as any).value).toBe('task 1');
+    expect(task2.type).toBe('listItem');
+    expect(task2.checked).toBe(true);
+    expect((task2.children[0] as any).value).toBe('task 2');
+    expect(task3.type).toBe('listItem');
+    expect(task3.checked).toBe(undefined);
+    expect((task3.children[0] as any).value).toBe('not a task');
+  });
+});

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -8,6 +8,7 @@ import type {
   Image as SpecImage,
   Admonition as SpecAdmonition,
   Code as SpecCode,
+  ListItem as SpecListItem,
 } from 'myst-spec';
 
 export type Delete = Parent & { type: 'delete' };
@@ -66,6 +67,10 @@ export type Admonition = SpecAdmonition & {
 
 export type Code = SpecCode & {
   executable?: boolean;
+};
+
+export type ListItem = SpecListItem & {
+  checked?: boolean;
 };
 
 export type CiteKind = 'narrative' | 'parenthetical';

--- a/packages/myst-transforms/src/blocks.ts
+++ b/packages/myst-transforms/src/blocks.ts
@@ -1,7 +1,7 @@
 import type { VFile } from 'vfile';
 import type { Plugin } from 'unified';
 import type { Root } from 'mdast';
-import type { Block, Node, Parent } from 'myst-spec';
+import type { Node, Parent } from 'myst-spec';
 import { select, selectAll } from 'unist-util-select';
 import { fileError, normalizeLabel } from 'myst-common';
 


### PR DESCRIPTION
This parses tasklists into an AST, previously they were going in as HTML. This adds a `checked` property to the AST.

![image](https://user-images.githubusercontent.com/913249/226709064-b38e7b6f-af36-4408-a2f4-05ac54b85ea2.png)
