### PR TITLE
© Copyright symbol must have trailing whitespace

### DIFF
--- a/.changeset/late-months-talk.md
+++ b/.changeset/late-months-talk.md
@@ -1,0 +1,5 @@
+---
+'myst-to-tex': patch
+---
+
+Copyright symbol must have trailing whitespace, see https://texfaq.org/FAQ-xspace

--- a/packages/myst-to-tex/src/utils.ts
+++ b/packages/myst-to-tex/src/utils.ts
@@ -36,11 +36,13 @@ const textOnlyReplacements: Record<string, string> = {
   '…': '\\dots',
   '–': '--',
   '—': '---',
-  '©': '\\textcopyright',
-  '®': '\\textregistered',
-  '™': '\\texttrademark',
-  '<': '\\textless',
-  '>': '\\textgreater',
+  // Commands gobble fhttps://texfaq.org/FAQ-xspaceollowing space
+  // See: https://texfaq.org/FAQ-xspace
+  '©': '\\textcopyright ',
+  '®': '\\textregistered ',
+  '™': '\\texttrademark ',
+  '<': '\\textless ',
+  '>': '\\textgreater ',
   ' ': '~',
 };
 


### PR DESCRIPTION
LaTeX commands gobble the following space, so this solution is safe https://texfaq.org/FAQ-xspace

See #199