### PR TITLE
🐛 Allow empty comments in myst-to-tex

### DIFF
--- a/.changeset/gold-eyes-tap.md
+++ b/.changeset/gold-eyes-tap.md
@@ -1,0 +1,5 @@
+---
+'myst-to-tex': patch
+---
+
+Fix bug where empty comment errors on myst-to-tex

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -116,12 +116,12 @@ const handlers: Record<string, Handler> = {
   },
   mystComment(node, state) {
     state.ensureNewLine();
-    state.write(`% ${node.value.split('\n').join('\n% ')}`);
+    state.write(`% ${node.value?.split('\n').join('\n% ') ?? ''}`);
     state.closeBlock(node);
   },
   comment(node, state) {
     state.ensureNewLine();
-    state.write(`% ${node.value.split('\n').join('\n% ')}`);
+    state.write(`% ${node.value?.split('\n').join('\n% ') ?? ''}`);
     state.closeBlock(node);
   },
   strong(node, state) {

--- a/packages/myst-to-tex/tests/basic.yml
+++ b/packages/myst-to-tex/tests/basic.yml
@@ -37,6 +37,14 @@ cases:
     latex: |-
       % hello
       % world
+  - title: comment - empty
+    mdast:
+      type: root
+      children:
+        - type: comment
+          value: null
+    latex: |-
+      %
   - title: figure directive - no caption/legend
     mdast:
       type: root


### PR DESCRIPTION
This fixes #325 where empty comment lines cause tex/pdf export to fail.