### PR TITLE
🏷 Add title/subtitle to JATS

### DIFF
--- a/.changeset/calm-llamas-fly.md
+++ b/.changeset/calm-llamas-fly.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Add subtitle and title to JATS

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -43,6 +43,50 @@ export function getJournalMeta(): Element[] {
   return elements.length ? [{ type: 'element', name: 'journal-meta', elements }] : [];
 }
 
+/**
+ * Add a article `title-group`, for example:
+ *
+ * ```xml
+ * <title-group>
+ *   <article-title>
+ *     Systematic review of day hospital care for elderly people
+ *   </article-title>
+ * </title-group>
+ * ```
+ *
+ * See: https://jats.nlm.nih.gov/archiving/tag-library/1.3/element/article-title.html
+ */
+export function getArticleTitle(frontmatter: ProjectFrontmatter): Element[] {
+  const title = frontmatter?.title;
+  const subtitle = frontmatter?.subtitle;
+  if (!title && !subtitle) return [];
+  const articleTitle: Element[] = title
+    ? [
+        {
+          type: 'element',
+          name: 'article-title',
+          elements: [{ type: 'text', text: title }],
+        },
+      ]
+    : [];
+  const articleSubtitle: Element[] = subtitle
+    ? [
+        {
+          type: 'element',
+          name: 'subtitle',
+          elements: [{ type: 'text', text: subtitle }],
+        },
+      ]
+    : [];
+  return [
+    {
+      type: 'element',
+      name: 'title-group',
+      elements: [...articleTitle, ...articleSubtitle],
+    },
+  ];
+}
+
 export function getArticleAuthors(frontmatter: ProjectFrontmatter): Element[] {
   // For now this just uses affiliations directly on each <contrib>, as they are defined in ProjectFrontmatter.
   // This should be changed to deduplicate / improve affiliations in frontmatter.
@@ -190,7 +234,7 @@ export function getArticleMeta(frontmatter: ProjectFrontmatter): Element[] {
     // article-id
     // article-version, article-version-alternatives
     // article-categories
-    // title-group
+    ...getArticleTitle(frontmatter),
     ...getArticleAuthors(frontmatter),
     // author-notes
     // pub-date or pub-date-not-available

--- a/packages/myst-to-jats/tests/article.yml
+++ b/packages/myst-to-jats/tests/article.yml
@@ -13,6 +13,52 @@ cases:
           <p>text</p>
         </body>
       </article>
+  - title: Article title
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      title: Hello title!
+    jats: |-
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <title-group>
+              <article-title>Hello title!</article-title>
+            </title-group>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>
+  - title: Article subtitle
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    frontmatter:
+      subtitle: Hello subtitle!
+    jats: |-
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta>
+            <title-group>
+              <subtitle>Hello subtitle!</subtitle>
+            </title-group>
+          </article-meta>
+        </front>
+        <body>
+          <p>text</p>
+        </body>
+      </article>
   - title: Biblio frontmatter
     tree:
       type: root


### PR DESCRIPTION
For example:
```xml
<title-group>
  <article-title>
    Systematic review of day hospital care for elderly people
  </article-title>
</title-group>
```

See https://jats.nlm.nih.gov/archiving/tag-library/1.3/element/article-title.html