### PR TITLE
💻 Extending project frontmatter to accept `thebe` options

### DIFF
--- a/.changeset/neat-flowers-laugh.md
+++ b/.changeset/neat-flowers-laugh.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Added a frontmatter field to hold `thebe` options, this includes a numebr of top level keys and nested options.

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -114,7 +114,6 @@ export async function getSiteManifest(
   const state = session.store.getState() as RootState;
   const siteConfig = selectors.selectCurrentSiteConfig(state);
   if (!siteConfig) throw Error('no site config defined');
-  // TODO HACK!
   await Promise.all(
     siteConfig.projects?.map(async (siteProj) => {
       if (!siteProj.path) return;

--- a/packages/myst-cli/src/build/site/manifest.ts
+++ b/packages/myst-cli/src/build/site/manifest.ts
@@ -60,6 +60,7 @@ export async function localToManifestProject(
       return { ...page };
     }),
   );
+
   const projFrontmatter = projConfig ? filterKeys(projConfig, PROJECT_FRONTMATTER_KEYS) : {};
   return {
     ...projFrontmatter,
@@ -113,6 +114,7 @@ export async function getSiteManifest(
   const state = session.store.getState() as RootState;
   const siteConfig = selectors.selectCurrentSiteConfig(state);
   if (!siteConfig) throw Error('no site config defined');
+  // TODO HACK!
   await Promise.all(
     siteConfig.projects?.map(async (siteProj) => {
       if (!siteProj.path) return;

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -8,6 +8,7 @@ import type {
   PageFrontmatter,
   ProjectFrontmatter,
   SiteFrontmatter,
+  Thebe,
 } from './types';
 import {
   fillPageFrontmatter,
@@ -21,6 +22,7 @@ import {
   validatePageFrontmatter,
   validateProjectFrontmatter,
   validateSiteFrontmatterKeys,
+  validateThebe,
   validateVenue,
 } from './validators';
 
@@ -43,6 +45,29 @@ const TEST_BIBLIO: Biblio = {
   first_page: 1,
   last_page: 2,
 };
+
+const TEST_THEBE: Thebe = {
+  useBinder: false,
+  useJupyterLite: false,
+  requestKernel: true,
+  binderOptions: {
+    binderUrl: 'https://my.binder.org/blah',
+    ref: 'HEAD',
+    repo: 'my-repo',
+    repoProvider: 'github',
+  },
+  serverSettings: {
+    baseUrl: 'http://localhost:8888',
+    token: 'test-secret',
+    wsUrl: 'ws://localhost:8888',
+    appendToken: true,
+  },
+  kernelOptions: { kernelName: 'python 3', name: 'python3', path: 'some-path' },
+  savedSessionOptions: { enabled: true, maxAge: 383000, storagePrefix: 'thebe' },
+  mathjaxConfig: 'TeX-AMS_CHTML-full,Safe',
+  mathjaxUrl: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js',
+};
+
 const TEST_NUMBERING: Numbering = {
   enumerator: '',
   figure: true,
@@ -198,6 +223,18 @@ describe('validateBiblio', () => {
   });
   it('full object returns self', async () => {
     expect(validateBiblio(TEST_BIBLIO, opts)).toEqual(TEST_BIBLIO);
+  });
+});
+
+describe('validateThebe', () => {
+  it('empty object returns self', async () => {
+    expect(validateThebe({}, opts)).toEqual({});
+  });
+  it('extra keys removed', async () => {
+    expect(validateThebe({ extra: '' }, opts)).toEqual({});
+  });
+  it('full object returns self', async () => {
+    expect(validateThebe(TEST_THEBE, opts)).toEqual(TEST_THEBE);
   });
 });
 

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -26,41 +26,41 @@ export type Biblio = {
 };
 
 export type Thebe = {
-  useBinder: boolean;
-  useJupyterLite: boolean;
-  requestkernel: boolean;
-  binderOptions: ThebeBinderOptions;
-  serverSettings: ThebeServerSettings;
-  kernelOptions: ThebeKernelOptions;
-  savedSessionOptions: ThebeSavedSessionOptions;
-  mathjaxConfig: string;
-  methjaxUrl: string;
+  useBinder?: boolean;
+  useJupyterLite?: boolean;
+  requestKernel?: boolean;
+  binderOptions?: ThebeBinderOptions;
+  serverSettings?: ThebeServerSettings;
+  kernelOptions?: ThebeKernelOptions;
+  savedSessionOptions?: ThebeSavedSessionOptions;
+  mathjaxConfig?: string;
+  methjaxUrl?: string;
 };
 
 export type ThebeBinderOptions = {
-  binderUrl: string;
-  ref: string;
-  repo: string;
-  repoProvider: string;
+  binderUrl?: string;
+  ref?: string;
+  repo?: string;
+  repoProvider?: string;
 };
 
 export type ThebeServerSettings = {
-  baseUrl: string;
-  token: string;
-  wsUrl: string;
-  appendToken: boolean;
+  baseUrl?: string;
+  token?: string;
+  wsUrl?: string;
+  appendToken?: boolean;
 };
 
 export type ThebeKernelOptions = {
-  kernelName: string;
-  name: string;
-  path: string;
+  kernelName?: string;
+  name?: string;
+  path?: string;
 };
 
 export type ThebeSavedSessionOptions = {
-  enabled: boolean;
-  maxAge: number;
-  storagePrefix: string;
+  enabled?: boolean;
+  maxAge?: string | number;
+  storagePrefix?: string;
 };
 
 export type Numbering = {

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -34,7 +34,7 @@ export type Thebe = {
   kernelOptions?: ThebeKernelOptions;
   savedSessionOptions?: ThebeSavedSessionOptions;
   mathjaxConfig?: string;
-  methjaxUrl?: string;
+  mathjaxUrl?: string;
 };
 
 export type ThebeBinderOptions = {

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -1,4 +1,5 @@
 import type { CreditRole } from 'credit-roles';
+import { SupportOptionRange } from 'prettier';
 import type { Licenses } from '../licenses/types';
 
 export type AuthorRoles = CreditRole | string;
@@ -22,6 +23,44 @@ export type Biblio = {
   issue?: string | number;
   first_page?: string | number;
   last_page?: string | number;
+};
+
+export type Thebe = {
+  useBinder: boolean;
+  useJupyterLite: boolean;
+  requestkernel: boolean;
+  binderOptions: ThebeBinderOptions;
+  serverSettings: ThebeServerSettings;
+  kernelOptions: ThebeKernelOptions;
+  savedSessionOptions: ThebeSavedSessionOptions;
+  mathjaxConfig: string;
+  methjaxUrl: string;
+};
+
+export type ThebeBinderOptions = {
+  binderUrl: string;
+  ref: string;
+  repo: string;
+  repoProvider: string;
+};
+
+export type ThebeServerSettings = {
+  baseUrl: string;
+  token: string;
+  wsUrl: string;
+  appendToken: boolean;
+};
+
+export type ThebeKernelOptions = {
+  kernelName: string;
+  name: string;
+  path: string;
+};
+
+export type ThebeSavedSessionOptions = {
+  enabled: boolean;
+  maxAge: number;
+  storagePrefix: string;
 };
 
 export type Numbering = {
@@ -87,6 +126,7 @@ export type SiteFrontmatter = {
   keywords?: string[];
 };
 
+// TODO extend
 export type ProjectFrontmatter = SiteFrontmatter & {
   date?: string;
   name?: string;
@@ -107,6 +147,7 @@ export type ProjectFrontmatter = SiteFrontmatter & {
   /** Math macros to be passed to KaTeX or LaTeX */
   math?: Record<string, string>;
   exports?: Export[];
+  thebe?: Thebe;
 };
 
 export type PageFrontmatter = Omit<ProjectFrontmatter, 'references'> & {

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -125,7 +125,6 @@ export type SiteFrontmatter = {
   keywords?: string[];
 };
 
-// TODO extend
 export type ProjectFrontmatter = SiteFrontmatter & {
   date?: string;
   name?: string;

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -1,5 +1,4 @@
 import type { CreditRole } from 'credit-roles';
-import { SupportOptionRange } from 'prettier';
 import type { Licenses } from '../licenses/types';
 
 export type AuthorRoles = CreditRole | string;

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -62,6 +62,7 @@ export const PROJECT_FRONTMATTER_KEYS = [
   'bibliography',
   'math',
   'exports',
+  'thebe',
 ].concat(SITE_FRONTMATTER_KEYS);
 export const PAGE_FRONTMATTER_KEYS = [
   'kernelspec',
@@ -458,6 +459,7 @@ export function validateGithubUrl(value: any, opts: ValidationOptions) {
   });
 }
 
+// TODO extend
 export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: ValidationOptions) {
   const output: SiteFrontmatter = {};
   if (defined(value.title)) {
@@ -613,6 +615,13 @@ export function validateProjectFrontmatterKeys(
           .filter((exists) => !!exists) as [string, { url: string }][],
       );
     }
+  }
+
+  if (defined(value.thebe)) {
+    // TODO
+    // fix type
+    // validate properly - check how biblio
+    output.thebe = value.thebe;
   }
   return output;
 }

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -116,7 +116,7 @@ const AUTHOR_ALIASES = {
 const BIBLIO_KEYS = ['volume', 'issue', 'first_page', 'last_page'];
 const THEBE_KEYS = [
   'useBinder',
-  'useJuyterLite',
+  'useJupyterLite',
   'requestKernel',
   'binderOptions',
   'serverSettings',
@@ -318,35 +318,56 @@ export function validateBiblio(input: any, opts: ValidationOptions) {
  * https://thebe-core.curve.space/docs-core/a-configuration
  */
 export function validateThebe(input: any, opts: ValidationOptions) {
-  const value = validateObjectKeys(input, { optional: THEBE_KEYS }, opts);
+  const value: Thebe | undefined = validateObjectKeys(input, { optional: THEBE_KEYS }, opts);
   if (value === undefined) return undefined;
   const output: Thebe = {};
   if (defined(value.useBinder)) {
-    output.useBinder = validateBoolean(output.useBinder, opts);
+    output.useBinder = validateBoolean(value.useBinder, incrementOptions('useBinder', opts));
   }
   if (defined(value.useJupyterLite)) {
-    output.useBinder = validateBoolean(output.useJupyterLite, opts);
+    output.useJupyterLite = validateBoolean(
+      value.useJupyterLite,
+      incrementOptions('useJupyterLite', opts),
+    );
   }
   if (defined(value.requestKernel)) {
-    output.useBinder = validateBoolean(output.requestKernel, opts);
+    output.requestKernel = validateBoolean(
+      value.requestKernel,
+      incrementOptions('requestKernel', opts),
+    );
   }
   if (defined(value.binderOptions)) {
-    output.binderOptions = validateThebeBinderOptions(input, opts);
+    output.binderOptions = validateThebeBinderOptions(
+      value.binderOptions,
+      incrementOptions('binderOptions', opts),
+    );
   }
-  if (defined(value.sercerSettings)) {
-    output.serverSettings = validateThebeServerSettings(input, opts);
+  if (defined(value.serverSettings)) {
+    output.serverSettings = validateThebeServerSettings(
+      value.serverSettings,
+      incrementOptions('serverSettings', opts),
+    );
   }
   if (defined(value.kernelOptions)) {
-    output.kernelOptions = validateThebeKernelOptions(input, opts);
+    output.kernelOptions = validateThebeKernelOptions(
+      value.kernelOptions,
+      incrementOptions('kernelOptions', opts),
+    );
   }
   if (defined(value.savedSessionOptions)) {
-    output.savedSessionOptions = validateThebeSavedSessionOptions(input, opts);
+    output.savedSessionOptions = validateThebeSavedSessionOptions(
+      value.savedSessionOptions,
+      incrementOptions('savedSessionOptions', opts),
+    );
   }
   if (defined(value.mathjaxUrl)) {
-    output.methjaxUrl = validateUrl(value.mathjaxUrl, opts);
+    output.mathjaxUrl = validateUrl(value.mathjaxUrl, incrementOptions('mathjaxUrl', opts));
   }
   if (defined(value.mathjaxConfig)) {
-    output.mathjaxConfig = validateString(value.mathjaxConfig, opts);
+    output.mathjaxConfig = validateString(
+      value.mathjaxConfig,
+      incrementOptions('mathjaxConfig', opts),
+    );
   }
   return output;
 }

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -34,6 +34,11 @@ import type {
   SiteFrontmatter,
   TextRepresentation,
   Venue,
+  Thebe,
+  ThebeBinderOptions,
+  ThebeKernelOptions,
+  ThebeSavedSessionOptions,
+  ThebeServerSettings,
 } from './types';
 
 export const SITE_FRONTMATTER_KEYS = [
@@ -109,6 +114,21 @@ const AUTHOR_ALIASES = {
   affiliation: 'affiliations',
 };
 const BIBLIO_KEYS = ['volume', 'issue', 'first_page', 'last_page'];
+const THEBE_KEYS = [
+  'useBinder',
+  'useJuyterLite',
+  'requestKernel',
+  'binderOptions',
+  'serverSettings',
+  'kernelOptions',
+  'savedSessionOptions',
+  'mathjaxConfig',
+  'mathjaxUrl',
+];
+const THEBE_BINDER_OPTIONS_KEYS = ['binderUrl', 'ref', 'repo', 'repoProvider'];
+const THEBE_SERVER_SETTINGS_KEYS = ['baseUrl', 'token', 'wsUrl', 'appendToken'];
+const THEBE_KERNEL_OPTIONS_KEYS = ['kernelName', 'name', 'path'];
+const THEBE_SAVED_SESSION_OPTIONS_KEYS = ['enabled', 'maxAge', 'storagePrefix'];
 const NUMBERING_KEYS = [
   'enumerator',
   'figure',
@@ -288,6 +308,115 @@ export function validateBiblio(input: any, opts: ValidationOptions) {
   }
   if (defined(value.last_page)) {
     output.last_page = validateStringOrNumber(value.last_page, incrementOptions('last_page', opts));
+  }
+  return output;
+}
+
+/**
+ * Validate Thebe Object
+ *
+ * https://thebe-core.curve.space/docs-core/a-configuration
+ */
+export function validateThebe(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { optional: THEBE_KEYS }, opts);
+  if (value === undefined) return undefined;
+  const output: Thebe = {};
+  if (defined(value.useBinder)) {
+    output.useBinder = validateBoolean(output.useBinder, opts);
+  }
+  if (defined(value.useJupyterLite)) {
+    output.useBinder = validateBoolean(output.useJupyterLite, opts);
+  }
+  if (defined(value.requestKernel)) {
+    output.useBinder = validateBoolean(output.requestKernel, opts);
+  }
+  if (defined(value.binderOptions)) {
+    output.binderOptions = validateThebeBinderOptions(input, opts);
+  }
+  if (defined(value.sercerSettings)) {
+    output.serverSettings = validateThebeServerSettings(input, opts);
+  }
+  if (defined(value.kernelOptions)) {
+    output.kernelOptions = validateThebeKernelOptions(input, opts);
+  }
+  if (defined(value.savedSessionOptions)) {
+    output.savedSessionOptions = validateThebeSavedSessionOptions(input, opts);
+  }
+  if (defined(value.mathjaxUrl)) {
+    output.methjaxUrl = validateUrl(value.mathjaxUrl, opts);
+  }
+  if (defined(value.mathjaxConfig)) {
+    output.mathjaxConfig = validateString(value.mathjaxConfig, opts);
+  }
+  return output;
+}
+
+export function validateThebeServerSettings(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { optional: THEBE_SERVER_SETTINGS_KEYS }, opts);
+  if (value === undefined) return undefined;
+  const output: ThebeServerSettings = {};
+  if (defined(value.baseUrl)) {
+    output.baseUrl = validateUrl(value.baseUrl, opts);
+  }
+  if (defined(value.token)) {
+    output.token = validateString(value.token, opts);
+  }
+  if (defined(value.wsUrl)) {
+    output.wsUrl = validateUrl(value.wsUrl, opts);
+  }
+  if (defined(value.appendToken)) {
+    output.appendToken = validateBoolean(value.appendToken, opts);
+  }
+  return output;
+}
+
+export function validateThebeKernelOptions(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { optional: THEBE_KERNEL_OPTIONS_KEYS }, opts);
+  if (value === undefined) return undefined;
+  const output: ThebeKernelOptions = {};
+  if (defined(value.kernelName)) {
+    output.kernelName = validateString(value.kernelName, opts);
+  }
+  if (defined(value.name)) {
+    output.name = validateString(value.name, opts);
+  }
+  if (defined(value.path)) {
+    output.path = validateString(value.path, opts);
+  }
+  return output;
+}
+
+export function validateThebeSavedSessionOptions(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { optional: THEBE_SAVED_SESSION_OPTIONS_KEYS }, opts);
+  if (value === undefined) return undefined;
+  const output: ThebeSavedSessionOptions = {};
+  if (defined(value.enabled)) {
+    output.enabled = validateBoolean(value.enabled, opts);
+  }
+  if (defined(value.maxAge)) {
+    output.maxAge = validateStringOrNumber(value.maxAge, opts);
+  }
+  if (defined(value.storagePrefix)) {
+    output.storagePrefix = validateString(value.storagePrefix, opts);
+  }
+  return output;
+}
+
+export function validateThebeBinderOptions(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { optional: THEBE_BINDER_OPTIONS_KEYS }, opts);
+  if (value === undefined) return undefined;
+  const output: ThebeBinderOptions = {};
+  if (defined(value.binderUrl)) {
+    output.binderUrl = validateUrl(value.binderUrl, opts);
+  }
+  if (defined(value.ref)) {
+    output.ref = validateString(value.ref, opts);
+  }
+  if (defined(value.repo)) {
+    output.repo = validateString(value.repo, opts);
+  }
+  if (defined(value.repoProvider)) {
+    output.repoProvider = validateString(value.repoProvider, opts);
   }
   return output;
 }
@@ -618,10 +747,7 @@ export function validateProjectFrontmatterKeys(
   }
 
   if (defined(value.thebe)) {
-    // TODO
-    // fix type
-    // validate properly - check how biblio
-    output.thebe = value.thebe;
+    output.thebe = validateThebe(value.thebe, incrementOptions('thebe', opts));
   }
   return output;
 }

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -609,7 +609,6 @@ export function validateGithubUrl(value: any, opts: ValidationOptions) {
   });
 }
 
-// TODO extend
 export function validateSiteFrontmatterKeys(value: Record<string, any>, opts: ValidationOptions) {
   const output: SiteFrontmatter = {};
   if (defined(value.title)) {

--- a/packages/myst-frontmatter/tests/examples.spec.ts
+++ b/packages/myst-frontmatter/tests/examples.spec.ts
@@ -26,6 +26,7 @@ const files = [
   'licenses.yml',
   'exports.yml',
   'keywords.yml',
+  'thebe.yml',
 ];
 
 const only = ''; // Can set this to a test title

--- a/packages/myst-frontmatter/tests/thebe.yml
+++ b/packages/myst-frontmatter/tests/thebe.yml
@@ -1,0 +1,53 @@
+title: THEBE
+cases:
+  - title: Valid and Exhaustive Options
+    raw:
+      thebe:
+        useBinder: false
+        useJupyterLite: false
+        requestKernel: true
+        binderOptions:
+          binderUrl: 'https://my.binder.org/blah'
+          ref: 'HEAD'
+          repo: 'my-repo'
+          repoProvider: 'github'
+        serverSettings:
+          baseUrl: http://localhost:8888
+          token: test-secret
+          wsUrl: ws://localhost:8888
+          appendToken: true
+        kernelOptions:
+          kernelName: 'python 3'
+          name: 'python3'
+          path: 'some-path'
+        savedSessionOptions:
+          enabled: true
+          maxAge: 383000
+          storagePrefix: thebe
+        mathjaxConfig: TeX-AMS_CHTML-full,Safe
+        mathjaxUrl: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js
+    normalized:
+      thebe:
+        useBinder: false
+        useJupyterLite: false
+        requestKernel: true
+        binderOptions:
+          binderUrl: 'https://my.binder.org/blah'
+          ref: 'HEAD'
+          repo: 'my-repo'
+          repoProvider: 'github'
+        serverSettings:
+          baseUrl: http://localhost:8888
+          token: test-secret
+          wsUrl: ws://localhost:8888
+          appendToken: true
+        kernelOptions:
+          kernelName: 'python 3'
+          name: 'python3'
+          path: 'some-path'
+        savedSessionOptions:
+          enabled: true
+          maxAge: 383000
+          storagePrefix: thebe
+        mathjaxConfig: TeX-AMS_CHTML-full,Safe
+        mathjaxUrl: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js


### PR DESCRIPTION
The `thebe`, `thebe-core` & `thebe-react` libraries accepts a number of options allowing connections to compute resources and rendering options to be configured. 

These options are currently documented [here](https://thebe-core.curve.space/docs-core/a-configuration) and [here](https://thebe-core.curve.space/docs-core/coreoptions).

This PR adds support for including these options in project frontmatter with the associated validation.