### PR TITLE
👩‍🎓 Add bibliography to JATS export backmatter

### DIFF
--- a/.changeset/shiny-windows-knock.md
+++ b/.changeset/shiny-windows-knock.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'myst-to-jats': patch
+---
+
+Add bibliogrpahy from citations to JATS export backmatter

--- a/.changeset/warm-oranges-reply.md
+++ b/.changeset/warm-oranges-reply.md
@@ -1,0 +1,5 @@
+---
+'citation-js-utils': patch
+---
+
+Export funciton to return citation data from cite in citation-js-utils

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -48,9 +48,13 @@ const defaultString: CitationFormatOptions = {
   style: CitationJSStyles.apa,
 };
 
-export function getInlineCitation(c: Cite, kind: InlineCite, opts?: InlineOptions) {
+export function getCiteData(c: Cite) {
   const cite = new Cite();
-  const data = cite.set(c).data[0];
+  return cite.set(c).data[0];
+}
+
+export function getInlineCitation(c: Cite, kind: InlineCite, opts?: InlineOptions) {
+  const data = getCiteData(c);
   let authors = data.author;
   if (!authors || authors.length === 0) {
     authors = data.editor;

--- a/packages/myst-to-jats/src/backmatter.ts
+++ b/packages/myst-to-jats/src/backmatter.ts
@@ -1,9 +1,137 @@
 import type { CitationRenderer } from 'citation-js-utils';
+import { getCiteData } from 'citation-js-utils';
 import type { Element } from './types';
+
+export function citeToJatsRef(key: string, cite: any): Element {
+  const data = getCiteData(cite);
+  const publicationType = !data.type || data.type === 'article-journal' ? 'journal' : data.type;
+  const elements: Element[] = [];
+  const authors: Element[] | undefined = data.author
+    ?.map((author: { given?: string; family?: string }) => {
+      if (!author.given && !author.family) return undefined;
+      const authorChildren: Element[] = [];
+      if (author.family) {
+        authorChildren.push({
+          type: 'element',
+          name: 'surname',
+          elements: [{ type: 'text', text: author.family }],
+        });
+      }
+      if (author.given) {
+        authorChildren.push({
+          type: 'element',
+          name: 'given-names',
+          elements: [{ type: 'text', text: author.given }],
+        });
+      }
+      const authorElem: Element = {
+        type: 'element',
+        name: 'name',
+        elements: authorChildren,
+      };
+      return authorElem;
+    })
+    .filter((author: Element | undefined) => !!author);
+  if (authors && authors.length) {
+    elements.push({
+      type: 'element',
+      name: 'person-group',
+      attributes: { 'person-group-type': 'author' },
+      elements: authors,
+    });
+  }
+  if (data.title) {
+    elements.push({
+      type: 'element',
+      name: 'article-title',
+      elements: [{ type: 'text', text: data.title }],
+    });
+  }
+  if (data['container-title']) {
+    elements.push({
+      type: 'element',
+      name: 'source',
+      elements: [{ type: 'text', text: data['container-title'] }],
+    });
+  }
+  const year = data.issued?.['date-parts']?.[0]?.[0];
+  if (year) {
+    elements.push({
+      type: 'element',
+      name: 'year',
+      attributes: { 'iso-8601-date': year },
+      elements: [{ type: 'text', text: year }],
+    });
+  }
+  if (data.DOI) {
+    elements.push({
+      type: 'element',
+      name: 'pub-id',
+      attributes: { 'pub-id-type': 'doi' },
+      elements: [{ type: 'text', text: data.DOI }],
+    });
+  }
+  if (data.volume) {
+    elements.push({
+      type: 'element',
+      name: 'volume',
+      elements: [{ type: 'text', text: data.volume }],
+    });
+  }
+  if (data.issue) {
+    elements.push({
+      type: 'element',
+      name: 'issue',
+      elements: [{ type: 'text', text: data.issue }],
+    });
+  }
+  if (data.page) {
+    const [firstPage, lastPage] = data.page.split('-');
+    if (firstPage) {
+      elements.push({
+        type: 'element',
+        name: 'fpage',
+        elements: [{ type: 'text', text: firstPage }],
+      });
+    }
+    if (lastPage) {
+      elements.push({
+        type: 'element',
+        name: 'lpage',
+        elements: [{ type: 'text', text: lastPage }],
+      });
+    }
+  }
+  if (data.ISSN) {
+    elements.push({
+      type: 'element',
+      name: 'issn',
+      elements: [{ type: 'text', text: data.ISSN }],
+    });
+  }
+  return {
+    type: 'element',
+    name: 'ref',
+    attributes: { id: key },
+    elements: [
+      {
+        type: 'element',
+        name: 'element-citation',
+        attributes: { 'publication-type': publicationType },
+        elements,
+      },
+    ],
+  };
+}
 
 export function getRefList(citations?: CitationRenderer): Element[] {
   if (!citations || !Object.keys(citations).length) return [];
-  return [{ type: 'element', name: 'ref-list', elements: [] }];
+  const elements = Object.keys(citations)
+    .sort()
+    .map((key) => {
+      return citeToJatsRef(key, citations[key].cite);
+    });
+  return [{ type: 'element', name: 'ref-list', elements }];
 }
 
 export function getFootnotes(footnotes?: Element[]): Element[] {

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -402,7 +402,7 @@ class JatsSerializer implements IJatsSerializer {
     if (articleType) attributes['article-type'] = articleType;
     if (specificUse) attributes['specific-use'] = specificUse;
     const front = getFront(this.options.frontmatter);
-    const back = getBack(this.options.bibliography, this.footnotes);
+    const back = getBack(this.options.citations, this.footnotes);
     const elements: Element[] = [];
     if (front) elements.push(front);
     elements.push({ type: 'element', name: 'body', elements: this.body() });

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -26,7 +26,7 @@ export type Options = {
   spaces?: number;
   fullArticle?: boolean;
   frontmatter?: ProjectFrontmatter;
-  bibliography?: CitationRenderer;
+  citations?: CitationRenderer;
 };
 
 export type StateData = {

--- a/packages/myst-to-jats/tests/basic.spec.ts
+++ b/packages/myst-to-jats/tests/basic.spec.ts
@@ -13,6 +13,7 @@ type TestCase = {
   tree: string;
   jats: string;
   frontmatter?: Record<string, any>;
+  citations?: Record<string, any>;
 };
 
 const directory = path.join('tests');
@@ -38,6 +39,19 @@ describe('JATS full article', () => {
     '%s',
     (_, { tree, jats, frontmatter }) => {
       const pipe = unified().use(mystToJats, { frontmatter, fullArticle: true, spaces: 2 });
+      pipe.runSync(tree as any);
+      const vfile = pipe.stringify(tree as any);
+      expect((vfile.result as JatsResult).value).toEqual(jats);
+    },
+  );
+});
+
+describe('JATS full article with bibliography', () => {
+  const cases = loadCases('citations.yml');
+  test.each(cases.map((c): [string, TestCase] => [c.title, c]))(
+    '%s',
+    (_, { tree, jats, citations }) => {
+      const pipe = unified().use(mystToJats, { citations, fullArticle: true, spaces: 2 });
       pipe.runSync(tree as any);
       const vfile = pipe.stringify(tree as any);
       expect((vfile.result as JatsResult).value).toEqual(jats);

--- a/packages/myst-to-jats/tests/citations.yml
+++ b/packages/myst-to-jats/tests/citations.yml
@@ -1,0 +1,68 @@
+cases:
+  - title: Full citation
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: text
+              value: text
+    citations:
+      doe_2000:
+        cite:
+          container-title: My Journal
+          author:
+            - given: Jane
+              family: Doe
+            - given: John
+              family: Doe
+          DOI: 10.1000/example.1000
+          type: article-journal
+          id: doe_2000
+          citation-key: doe_2000
+          ISSN: 2000-300X
+          issue: '1'
+          issued:
+            date-parts:
+              - - '2000'
+          page: 83-92
+          title: My Title!
+          volume: '4'
+      example_2020:
+        cite: {}
+    jats: |-
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" dtd-version="1.3" xml:lang="en">
+        <body>
+          <p>text</p>
+        </body>
+        <back>
+          <ref-list>
+            <ref id="doe_2000">
+              <element-citation publication-type="journal">
+                <person-group person-group-type="author">
+                  <name>
+                    <surname>Doe</surname>
+                    <given-names>Jane</given-names>
+                  </name>
+                  <name>
+                    <surname>Doe</surname>
+                    <given-names>John</given-names>
+                  </name>
+                </person-group>
+                <article-title>My Title!</article-title>
+                <source>My Journal</source>
+                <year iso-8601-date="2000">2000</year>
+                <pub-id pub-id-type="doi">10.1000/example.1000</pub-id>
+                <volume>4</volume>
+                <issue>1</issue>
+                <fpage>83</fpage>
+                <lpage>92</lpage>
+                <issn>2000-300X</issn>
+              </element-citation>
+            </ref>
+            <ref id="example_2020">
+              <element-citation publication-type="journal"/>
+            </ref>
+          </ref-list>
+        </back>
+      </article>

--- a/packages/myst-to-jats/tests/citations.yml
+++ b/packages/myst-to-jats/tests/citations.yml
@@ -31,7 +31,7 @@ cases:
       example_2020:
         cite: {}
     jats: |-
-      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" dtd-version="1.3" xml:lang="en">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>text</p>
         </body>


### PR DESCRIPTION
Currently this handles basic journal citations. It will need a bit of expanding for other citation types. We could also move some of this handling to `citation-js-utils` so all the cite transformations / exports are centralized there...?

For now, though, I think this is a nice placeholder start.