### PR TITLE
📒 Track notebook source for embedded content

### DIFF
--- a/.changeset/forty-pugs-drop.md
+++ b/.changeset/forty-pugs-drop.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Do not publish local file paths to site json

--- a/.changeset/olive-pianos-film.md
+++ b/.changeset/olive-pianos-film.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add source url / key to embed nodes in mdast

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -177,6 +177,8 @@ export async function transformMdast(
   await transformThumbnail(session, mdast, file, frontmatter, imageWriteFolder, {
     altOutputFolder: imageAltOutputFolder,
   });
+  // Ensure there are keys on every node early
+  keysTransform(mdast);
   const sha256 = selectors.selectFileInfo(store.getState(), file).sha256 as string;
   store.dispatch(
     watch.actions.updateFileInfo({
@@ -196,6 +198,7 @@ export async function transformMdast(
     file,
     sha256,
     slug: pageSlug,
+    dependencies: [],
     frontmatter,
     mdast,
     references,
@@ -243,8 +246,8 @@ export async function postProcessMdast(
     selector: LINKS_SELECTOR,
   });
   resolveReferencesTransform(mdastPost.mdast, state.file as VFile, { state });
-  embedDirective(mdastPost.mdast, state);
-  // Ensure there are keys on every node
+  embedDirective(mdastPost.mdast, mdastPost.dependencies, state);
+  // Ensure there are keys on every node after post processing
   keysTransform(mdastPost.mdast);
   logMessagesFromVFile(session, fileState.file);
   log.debug(toc(`Transformed mdast cross references and links for "${file}" in %s`));

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -177,8 +177,6 @@ export async function transformMdast(
   await transformThumbnail(session, mdast, file, frontmatter, imageWriteFolder, {
     altOutputFolder: imageAltOutputFolder,
   });
-  // Ensure there are keys on every node early
-  keysTransform(mdast);
   const sha256 = selectors.selectFileInfo(store.getState(), file).sha256 as string;
   store.dispatch(
     watch.actions.updateFileInfo({
@@ -246,7 +244,7 @@ export async function postProcessMdast(
     selector: LINKS_SELECTOR,
   });
   resolveReferencesTransform(mdastPost.mdast, state.file as VFile, { state });
-  embedDirective(mdastPost.mdast, mdastPost.dependencies, state);
+  embedDirective(session, mdastPost.mdast, mdastPost.dependencies, state);
   // Ensure there are keys on every node after post processing
   keysTransform(mdastPost.mdast);
   logMessagesFromVFile(session, fileState.file);

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -179,7 +179,7 @@ export async function writeFile(
   const toc = tic();
   const selectedFile = selectFile(session, file);
   if (!selectedFile) return;
-  const { frontmatter, ...mdastPost } = selectedFile;
+  const { frontmatter, mdast, kind, sha256, slug, references, dependencies } = selectedFile;
   const exports = await Promise.all([
     resolvePageSource(session, file),
     ...(await resolvePageExports(session, file, projectPath)),
@@ -189,8 +189,13 @@ export async function writeFile(
   writeFileToFolder(
     jsonFilename,
     JSON.stringify({
+      kind,
+      sha256,
+      slug,
+      dependencies,
       frontmatter: frontmatterWithExports,
-      ...mdastPost,
+      mdast,
+      references,
     }),
   );
   session.log.debug(toc(`Wrote "${file}" in %s`));

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -1,14 +1,14 @@
 import type { Root } from 'mdast';
 import { filter } from 'unist-util-filter';
 import { selectAll } from 'unist-util-select';
-import type { IReferenceState } from 'myst-transforms';
+import type { IReferenceState, MultiPageReferenceState } from 'myst-transforms';
 import type { GenericNode } from 'myst-common';
 import { copyNode, normalizeLabel } from 'myst-common';
 
 /**
  * This is the {embed} directive, that embeds nodes from elsewhere in a page.
  */
-export function embedDirective(mdast: Root, state: IReferenceState) {
+export function embedDirective(mdast: Root, dependencies: string[], state: IReferenceState) {
   const embedNodes = selectAll('embed', mdast) as GenericNode[];
   embedNodes.forEach((node) => {
     const normalized = normalizeLabel(node.label);
@@ -23,5 +23,15 @@ export function embedDirective(mdast: Root, state: IReferenceState) {
       newNode = filter(newNode, (n: GenericNode) => n.type !== 'code');
     }
     node.children = newNode ? [newNode] : [];
+    const multiState = state as MultiPageReferenceState;
+    if (multiState.states) {
+      const { url } = multiState.resolveStateProvider(normalized.identifier) ?? {};
+      if (url) {
+        node.source = url;
+        if (!dependencies.includes(url)) dependencies.push(url);
+      }
+      const sourceKey = (target.node as any).key;
+      if (sourceKey) node.sourceKey = sourceKey;
+    }
   });
 }

--- a/packages/myst-cli/src/transforms/types.ts
+++ b/packages/myst-cli/src/transforms/types.ts
@@ -8,6 +8,11 @@ export enum KINDS {
   Notebook = 'Notebook',
 }
 
+export type Dependency = {
+  url: string;
+  kind?: KINDS;
+};
+
 export type PreRendererData = {
   file: string;
   mdast: Root;
@@ -20,7 +25,7 @@ export type RendererData = PreRendererData & {
   slug?: string;
   frontmatter: PageFrontmatter;
   references: References;
-  dependencies: string[];
+  dependencies: Dependency[];
 };
 
 export type SingleCitationRenderer = { id: string; render: CitationRenderer[''] };

--- a/packages/myst-cli/src/transforms/types.ts
+++ b/packages/myst-cli/src/transforms/types.ts
@@ -20,6 +20,7 @@ export type RendererData = PreRendererData & {
   slug?: string;
   frontmatter: PageFrontmatter;
   references: References;
+  dependencies: string[];
 };
 
 export type SingleCitationRenderer = { id: string; render: CitationRenderer[''] };

--- a/packages/myst-directives/src/embed.ts
+++ b/packages/myst-directives/src/embed.ts
@@ -1,5 +1,5 @@
 import type { DirectiveSpec, DirectiveData, GenericNode } from 'myst-common';
-import { ParseTypesEnum } from 'myst-common';
+import { normalizeLabel, ParseTypesEnum } from 'myst-common';
 
 export const embedDirective: DirectiveSpec = {
   name: 'embed',
@@ -16,10 +16,12 @@ export const embedDirective: DirectiveSpec = {
     },
   },
   run(data: DirectiveData): GenericNode[] {
+    const { label, identifier } = normalizeLabel(data.options?.label as string) || {};
     return [
       {
         type: 'embed',
-        label: data.options?.label as string,
+        label,
+        identifier,
         'remove-input': data.options?.['remove-input'],
         'remove-output': data.options?.['remove-output'],
       },

--- a/packages/myst-parser/tests/directives/embed.yml
+++ b/packages/myst-parser/tests/directives/embed.yml
@@ -17,4 +17,5 @@ cases:
           children:
             - type: embed
               label: hi
+              identifier: hi
               remove-output: true


### PR DESCRIPTION
`figure`/`embed` directives may embed code/output cells from other notebooks. To recompute these, we need to know where they come from.

This PR adds url `source` and `sourceKey` to all embed nodes to locate the source notebook cell. This also adds `dependencies` at the top level of the page config with all url sources required to compute embedded content in the page.