### PR TITLE
🤖 identify `ipynb` code cells as `code-cell` directives

### DIFF
--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -57,7 +57,7 @@ export async function processNotebook(
       return acc.concat(`${blockDivider(cell)}\`\`\`\n${asString(cell.source)}\n\`\`\``);
     }
     if (cell.cell_type === CELL_TYPES.code) {
-      const code = `\`\`\`${language}\n${asString(cell.source)}\n\`\`\``;
+      const code = `\`\`\`{code-cell} ${language}\n${asString(cell.source)}\n\`\`\``;
       if (cell.outputs && (cell.outputs as IOutput[]).length > 0) {
         const minified: MinifiedOutput[] = await minifyCellOutput(
           cell.outputs as IOutput[],


### PR DESCRIPTION
This PR uses the `code-cell` directive to represent code cells in when processing `ipynb` notebooks, the resulting `mdast` nodes are `code` and flagged as `executable`

![image](https://user-images.githubusercontent.com/1473646/228906835-f6f4df27-b4d3-47b5-a5dc-65600d1cbe90.png)
