### PR TITLE
⛹️ always include outputs with code cells

### DIFF
--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -58,17 +58,18 @@ export async function processNotebook(
     }
     if (cell.cell_type === CELL_TYPES.code) {
       const code = `\`\`\`${language}\n${asString(cell.source)}\n\`\`\``;
+      const { myst, id } = createOutputDirective();
       if (cell.outputs && (cell.outputs as IOutput[]).length > 0) {
         const minified: MinifiedOutput[] = await minifyCellOutput(
           cell.outputs as IOutput[],
           cache.$outputs,
           { computeHash, maxCharacters: opts?.minifyMaxCharacters },
         );
-        const { myst, id } = createOutputDirective();
         outputMap[id] = minified;
-        return acc.concat(`${blockDivider(cell)}${code}\n\n${myst}`);
+      } else {
+        outputMap[id] = [];
       }
-      return acc.concat(`${blockDivider(cell)}${code}`);
+      return acc.concat(`${blockDivider(cell)}${code}\n\n${myst}`);
     }
     return acc;
   }, Promise.resolve([] as string[]));


### PR DESCRIPTION
This always adds an output array to blocks that represent `code-cell`s in the ast, even when the outputs array is empty. This is consistent with `ipynb` format, where the `outputs` array is always present.