### PR TITLE
🐛 Transform Wikipedia links properly

### DIFF
--- a/packages/myst-transforms/src/links/plugin.ts
+++ b/packages/myst-transforms/src/links/plugin.ts
@@ -17,7 +17,8 @@ type Options = {
 function formatLinkText(link: Link) {
   if (link.children?.length !== 1 || link.children[0].type !== 'text') return;
   const url = link.children[0].value;
-  if (url.length < 20 || url.match(/\s/)) return;
+  // Add an exception for wiki transforms links.
+  if (url.length < 20 || url.match(/\s/) || url.startsWith('wiki:')) return;
   // Split the URL into an array to distinguish double slashes from single slashes
   const doubleSlash = url.split('//');
   // Format the strings on either side of double slashes separately

--- a/packages/myst-transforms/src/links/wiki.spec.ts
+++ b/packages/myst-transforms/src/links/wiki.spec.ts
@@ -8,15 +8,31 @@ describe('Test WikiTransformer', () => {
     const t = new WikiTransformer();
     const link: Link = {
       type: 'link',
-      url: 'wiki:hello there',
+      url: 'wiki:hello_there_world',
       children: [],
     };
     expect(t.test(link.url)).toBe(true);
     expect(t.transform(link, file)).toBe(true);
-    expect(link.url).toBe('https://en.wikipedia.org/wiki/hello_there');
-    expect(link.children).toEqual([{ type: 'text', value: 'hello there' }]);
+    expect(link.url).toBe('https://en.wikipedia.org/wiki/hello_there_world');
+    expect(link.children).toEqual([{ type: 'text', value: 'hello there world' }]);
     expect(link.data?.wiki).toEqual('https://en.wikipedia.org/');
-    expect(link.data?.page).toEqual('hello_there');
+    expect(link.data?.page).toEqual('hello_there_world');
+  });
+  test('Test with pre populated children', async () => {
+    const file = new VFile();
+    const t = new WikiTransformer();
+    const link: Link = {
+      type: 'link',
+      url: 'wiki:hello_there_world',
+      children: [{ type: 'text', value: 'wiki:hello_there_world' }],
+    };
+    expect(t.test(link.url)).toBe(true);
+    expect(t.transform(link, file)).toBe(true);
+    expect(link.url).toBe('https://en.wikipedia.org/wiki/hello_there_world');
+    // This only works when run via myst-cli
+    // expect(link.children).toEqual([{ type: 'text', value: 'hello there world' }]);
+    expect(link.data?.wiki).toEqual('https://en.wikipedia.org/');
+    expect(link.data?.page).toEqual('hello_there_world');
   });
   test('any wiki link', async () => {
     const file = new VFile();

--- a/packages/myst-transforms/src/links/wiki.ts
+++ b/packages/myst-transforms/src/links/wiki.ts
@@ -88,7 +88,7 @@ export class WikiTransformer implements LinkTransformer {
       lang: result.lang,
     };
     link.internal = false;
-    const title = page.replace(/_/, ' ');
+    const title = page.replace(/_/g, ' ');
     updateLinkTextIfEmpty(link, title);
     return true;
   }


### PR DESCRIPTION
This fixes https://github.com/executablebooks/mystjs/issues/224 (maybe in a bit hacky way).

The wiki link string was being manipulated by adding zero width space by https://github.com/executablebooks/mystjs/blob/8615f221874abb8542176ceeb0e8f8e2da42777e/packages/myst-transforms/src/links/plugin.ts#L20 
which in turn messed up updates to the text.

Also fixed a regex, so `The_big_bang_theory`, correctly transforms to `The big bang theory` and not `The big_bang_theory`.