### PR TITLE
🐛 Citations in JATS can't use citation-js

### DIFF
--- a/.changeset/sour-ants-relax.md
+++ b/.changeset/sour-ants-relax.md
@@ -1,0 +1,6 @@
+---
+'citation-js-utils': patch
+'myst-to-jats': patch
+---
+
+Improve citation-js types, remove dependency on citation-js in jats export.

--- a/packages/citation-js-utils/src/index.ts
+++ b/packages/citation-js-utils/src/index.ts
@@ -2,6 +2,26 @@ import type { CitationFormatOptions } from 'citation-js';
 import Cite from 'citation-js';
 import sanitizeHtml from 'sanitize-html';
 
+// This is duplicated in citation-js types, which are not exported
+export type CitationJson = {
+  type?: 'article-journal' | string;
+  id: string;
+  author?: { given: string; family: string }[];
+  issued?: { 'date-parts': number[][] };
+  publisher?: string;
+  title?: string;
+  'citation-key'?: string;
+  'container-title'?: string;
+  abstract?: string;
+  DOI?: string;
+  ISBN?: string;
+  ISSN?: string;
+  issue?: string;
+  keyword?: string;
+  page?: string;
+  volume?: string;
+} & Record<string, any>;
+
 export type InlineNode = {
   type: string;
   value?: string;
@@ -48,13 +68,7 @@ const defaultString: CitationFormatOptions = {
   style: CitationJSStyles.apa,
 };
 
-export function getCiteData(c: Cite) {
-  const cite = new Cite();
-  return cite.set(c).data[0];
-}
-
-export function getInlineCitation(c: Cite, kind: InlineCite, opts?: InlineOptions) {
-  const data = getCiteData(c);
+export function getInlineCitation(data: CitationJson, kind: InlineCite, opts?: InlineOptions) {
   let authors = data.author;
   if (!authors || authors.length === 0) {
     authors = data.editor;
@@ -95,7 +109,7 @@ export type CitationRenderer = Record<
     render: (style?: CitationJSStyles) => string;
     inline: (kind?: InlineCite, opts?: InlineOptions) => InlineNode[];
     getDOI: () => string | undefined;
-    cite: any;
+    cite: CitationJson;
   }
 >;
 

--- a/packages/citation-js-utils/types/citation-js/index.d.ts
+++ b/packages/citation-js-utils/types/citation-js/index.d.ts
@@ -16,13 +16,24 @@ declare module 'citation-js' {
     lang: 'en-US' | 'fr-FR' | 'es-ES' | 'de-DE' | 'nl-NL';
   };
 
+  // This is duplicated for export in index.ts
   export type CitationJson = {
+    type?: 'article-journal' | string;
     id: string;
     author?: { given: string; family: string }[];
-    issued: { 'date-parts': number[][] };
+    issued?: { 'date-parts': number[][] };
     publisher?: string;
     title?: string;
     'citation-key'?: string;
+    'container-title'?: string;
+    abstract?: string;
+    DOI?: string;
+    ISBN?: string;
+    ISSN?: string;
+    issue?: string;
+    keyword?: string;
+    page?: string;
+    volume?: string;
   } & Record<string, any>;
 
   export class Cite {

--- a/packages/myst-to-jats/src/backmatter.ts
+++ b/packages/myst-to-jats/src/backmatter.ts
@@ -1,13 +1,11 @@
-import type { CitationRenderer } from 'citation-js-utils';
-import { getCiteData } from 'citation-js-utils';
+import type { CitationRenderer, CitationJson } from 'citation-js-utils';
 import type { Element } from './types';
 
-export function citeToJatsRef(key: string, cite: any): Element {
-  const data = getCiteData(cite);
+export function citeToJatsRef(key: string, data: CitationJson): Element {
   const publicationType = !data.type || data.type === 'article-journal' ? 'journal' : data.type;
   const elements: Element[] = [];
   const authors: Element[] | undefined = data.author
-    ?.map((author: { given?: string; family?: string }) => {
+    ?.map((author) => {
       if (!author.given && !author.family) return undefined;
       const authorChildren: Element[] = [];
       if (author.family) {
@@ -31,7 +29,7 @@ export function citeToJatsRef(key: string, cite: any): Element {
       };
       return authorElem;
     })
-    .filter((author: Element | undefined) => !!author);
+    .filter((author: Element | undefined): author is Element => !!author);
   if (authors && authors.length) {
     elements.push({
       type: 'element',
@@ -59,8 +57,8 @@ export function citeToJatsRef(key: string, cite: any): Element {
     elements.push({
       type: 'element',
       name: 'year',
-      attributes: { 'iso-8601-date': year },
-      elements: [{ type: 'text', text: year }],
+      attributes: { 'iso-8601-date': String(year) },
+      elements: [{ type: 'text', text: String(year) }],
     });
   }
   if (data.DOI) {


### PR DESCRIPTION
This fixes an error in downstream packaging for using the JATS export.