### PR TITLE
🎚allow thebe to be disabled without removing `frontmattter` section

### DIFF
--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -47,6 +47,7 @@ const TEST_BIBLIO: Biblio = {
 };
 
 const TEST_THEBE: Thebe = {
+  enabled: false,
   useBinder: false,
   useJupyterLite: false,
   requestKernel: true,
@@ -227,14 +228,20 @@ describe('validateBiblio', () => {
 });
 
 describe('validateThebe', () => {
-  it('empty object returns self', async () => {
-    expect(validateThebe({}, opts)).toEqual({});
+  it('empty object returns self with enabled true', async () => {
+    expect(validateThebe({}, opts)).toEqual({ enabled: true });
   });
   it('extra keys removed', async () => {
-    expect(validateThebe({ extra: '' }, opts)).toEqual({});
+    expect(validateThebe({ extra: '' }, opts)).toEqual({ enabled: true });
   });
-  it('full object returns self', async () => {
+  it('full object returns self - enabled false', async () => {
     expect(validateThebe(TEST_THEBE, opts)).toEqual(TEST_THEBE);
+  });
+  it('full object returns self - enabled true', async () => {
+    expect(validateThebe({ ...TEST_THEBE, enabled: true }, opts)).toEqual({
+      ...TEST_THEBE,
+      enabled: true,
+    });
   });
 });
 

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -25,6 +25,7 @@ export type Biblio = {
 };
 
 export type Thebe = {
+  enabled?: boolean;
   useBinder?: boolean;
   useJupyterLite?: boolean;
   requestKernel?: boolean;

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -115,6 +115,7 @@ const AUTHOR_ALIASES = {
 };
 const BIBLIO_KEYS = ['volume', 'issue', 'first_page', 'last_page'];
 const THEBE_KEYS = [
+  'enabled',
   'useBinder',
   'useJupyterLite',
   'requestKernel',
@@ -321,6 +322,11 @@ export function validateThebe(input: any, opts: ValidationOptions) {
   const value: Thebe | undefined = validateObjectKeys(input, { optional: THEBE_KEYS }, opts);
   if (value === undefined) return undefined;
   const output: Thebe = {};
+  if (defined(value.enabled)) {
+    output.enabled = validateBoolean(value.enabled, incrementOptions('enabled', opts));
+  } else {
+    output.enabled = true;
+  }
   if (defined(value.useBinder)) {
     output.useBinder = validateBoolean(value.useBinder, incrementOptions('useBinder', opts));
   }

--- a/packages/myst-frontmatter/tests/thebe.yml
+++ b/packages/myst-frontmatter/tests/thebe.yml
@@ -28,6 +28,7 @@ cases:
         mathjaxUrl: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js
     normalized:
       thebe:
+        enabled: true
         useBinder: false
         useJupyterLite: false
         requestKernel: true


### PR DESCRIPTION
The purpose of this change is to allow someone wants to disable thebe without having to delete the whole `thebe` section from their frontmatter. The intent was to add a flag within the thebe section, that if not included still meant that thebe should be enabled.

The current change uses an `enabled` flag, which is assumed `true` is missing, and only has an affect when `enabled: false`. 

i.e. the following two cases are equivalent

```yaml
thebe:
   useBinder: true
   binderOptions:
      ...
```

```yaml
thebe:
   enabled: true
   useBinder: true
   binderOptions:
      ...
```

while the following would see thebe being disabled:

```yaml
thebe:
   enabled: false
   useBinder: true
   binderOptions:
      ...
```

Is it better to just flip this and use a `disabled` flag?
