### PR TITLE
Ş Allow characters in groups

### DIFF
--- a/.changeset/grumpy-dingos-thank.md
+++ b/.changeset/grumpy-dingos-thank.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Groups of accented characters are picked up correctly

--- a/.changeset/tough-ties-punch.md
+++ b/.changeset/tough-ties-punch.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Allow characters in groups {\c S} --> Ş

--- a/packages/tex-to-myst/src/characters.ts
+++ b/packages/tex-to-myst/src/characters.ts
@@ -2,16 +2,30 @@ import type { Handler, ITexParser } from './types';
 import { getArguments, texToText } from './utils';
 import type { GenericNode } from 'myst-common';
 
+/** https://en.wikipedia.org/wiki/Thin_space */
+export const THIN_SPACE = ' ';
+
+/** https://en.wikipedia.org/wiki/Non-breaking_space#Width_variation */
+export const NARROW_NO_BREAK_SPACE = ' ';
+
 function createText(state: ITexParser, node: GenericNode, translate: Record<string, string>) {
   state.openParagraph();
-  const value = texToText(getArguments(node, 'group'));
-  const converted = translate[value];
-  if (converted) {
-    state.text(converted, false);
+  const values = texToText(getArguments(node, 'group'));
+  // If the exact value is included
+  const exact = translate[values];
+  if (exact) {
+    state.text(exact, false);
     return;
   }
-  state.warn(`Unknown character ${value}`, node, 'tex-to-myst:characters');
-  state.text(converted, false);
+  values.split('').forEach((value) => {
+    const converted = translate[value];
+    if (converted) {
+      state.text(converted, false);
+      return;
+    }
+    state.warn(`Unknown character "${value}"`, node, 'tex-to-myst:characters');
+    state.text(converted, false);
+  });
 }
 
 function addText(state: ITexParser, value?: string) {
@@ -29,7 +43,7 @@ export const LatexAccents = {
   '"': { o: 'ö', u: 'ü', i: 'ï', O: 'Ö', U: 'Ü', I: 'Ï' },
   H: { o: 'ő', O: 'Ő' },
   '~': { '': '~', o: 'õ', n: 'ñ', O: 'Õ', N: 'Ñ', u: 'ũ', U: 'Ũ', e: 'ẽ', E: 'Ẽ', i: 'ĩ', I: 'Ĩ' },
-  c: { c: 'ç', C: 'Ç' },
+  c: { c: 'ç', C: 'Ç', s: 'ş', S: 'Ş' },
   k: { a: 'ą', A: 'Ą' },
   l: { '': 'ł' },
   '=': { o: 'ō', O: 'Ō' },
@@ -82,7 +96,7 @@ export const LatexSpecialSymbols = {
   textasciitilde: '~',
   textvisiblespace: ' ', // Not sure this will work, but close enough
   ' ': ' ', // this is a single backslash followed by a space
-  ',': ' ', // this is a thin space (https://en.wikipedia.org/wiki/Thin_space) `\,` in latex
+  ',': THIN_SPACE, // this is a thin space (https://en.wikipedia.org/wiki/Thin_space) `\,` in latex
 };
 
 const CHARACTER_HANDLERS: Record<string, Handler> = {

--- a/packages/tex-to-myst/src/utils.ts
+++ b/packages/tex-to-myst/src/utils.ts
@@ -1,7 +1,7 @@
 import type { GenericNode } from 'myst-common';
 import { copyNode } from 'myst-common';
 import { selectAll } from 'unist-util-select';
-import { LatexSpecialSymbols } from './characters';
+import { LatexAccents, LatexSpecialSymbols } from './characters';
 
 export const phrasingTypes = new Set([
   'paragraph',
@@ -59,8 +59,14 @@ export function replaceTextValue(value?: string): string {
   }, value);
 }
 
-export function isSpecialSymbol(node: GenericNode): boolean {
-  if (node.type !== 'macro') return false;
+export function isAccent(node?: GenericNode): boolean {
+  if (node?.type !== 'macro') return false;
+  if (node.content in LatexAccents) return true;
+  return false;
+}
+
+export function isSpecialSymbol(node?: GenericNode): boolean {
+  if (node?.type !== 'macro') return false;
   if (node.content in LatexSpecialSymbols) return true;
   return false;
 }

--- a/packages/tex-to-myst/tests/characters.yml
+++ b/packages/tex-to-myst/tests/characters.yml
@@ -37,6 +37,12 @@ cases:
   - title: ç (cedilla)
     tex: \c{c}
     text: ç
+  - title: ş (cedilla)
+    tex: \c{s}
+    text: ş
+  - title: Şşç (cedilla)
+    tex: '{\c Ssc}'
+    text: Şşç
   - title: ą (ogonek)
     tex: \k{a}
     text: ą
@@ -56,8 +62,8 @@ cases:
     tex: \d{u}
     text: ụ
   - title: åÅ (ring over the letter)
-    tex: \r{a}\aa\AA
-    text: ååÅ
+    tex: \r{a} \aa \AA and as a group {\r aA}
+    text: å å Å and as a group åÅ
   - title: ŏ (breve over the letter)
     tex: \u{o}
     text: ŏ


### PR DESCRIPTION
This allows LaTeX parsing of `{\c S} --> Ş`, and any other accents.