### PR TITLE
⌨️ No-break space for cross-references

### DIFF
--- a/.changeset/new-months-ring.md
+++ b/.changeset/new-months-ring.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Ensure that Figure cross-references have no-break-spaces

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -31,17 +31,18 @@ export enum TargetKind {
 function getDefaultNumberedReferenceLabel(kind: TargetKind | string) {
   switch (kind) {
     case TargetKind.heading:
-      return 'Section %s';
+      return 'Section %s';
     case TargetKind.equation:
       return '(%s)';
     case TargetKind.figure:
-      return 'Figure %s';
+      return 'Figure %s';
     case TargetKind.table:
-      return 'Table %s';
+      return 'Table %s';
     case TargetKind.code:
-      return 'Program %s';
+      return 'Program %s';
     default:
-      return `${kind.slice(0, 1).toUpperCase()}${kind.slice(1)} %s`;
+      // eslint-disable-next-line no-irregular-whitespace
+      return `${kind.slice(0, 1).toUpperCase()}${kind.slice(1)} %s`;
   }
 }
 


### PR DESCRIPTION
i.e. `Figure~1` in LaTeX