### PR TITLE
🐛 Await all extra transforms to be completed

### DIFF
--- a/.changeset/eight-islands-decide.md
+++ b/.changeset/eight-islands-decide.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Bug where we were not waiting for webp to be built, meaning large images!

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -204,9 +204,11 @@ export async function transformMdast(
   };
   cache.$mdast[file].post = data;
   if (extraTransforms) {
-    extraTransforms.forEach(async (transform) => {
-      await transform(session, opts);
-    });
+    await Promise.all(
+      extraTransforms.map(async (transform) => {
+        await transform(session, opts);
+      }),
+    );
   }
   logMessagesFromVFile(session, vfile);
   if (!watchMode) log.info(toc(`📖 Built ${file} in %s.`));


### PR DESCRIPTION
Traced a bug in not having the webp images show up back to this!