### PR TITLE
🧐 Add JATS DTD validation to myst-to-jats tests

### DIFF
--- a/.changeset/dirty-dolls-pull.md
+++ b/.changeset/dirty-dolls-pull.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Add doctype header to myst-to-jats output

--- a/.changeset/great-mugs-grow.md
+++ b/.changeset/great-mugs-grow.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Add declaration to fullArticle JATS export

--- a/.changeset/heavy-impalas-hammer.md
+++ b/.changeset/heavy-impalas-hammer.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Update myst-to-jats conversion for DTD compliance

--- a/.changeset/tiny-flies-bathe.md
+++ b/.changeset/tiny-flies-bathe.md
@@ -1,0 +1,5 @@
+---
+'myst-to-jats': patch
+---
+
+Add DTD validation to myst-to-jats tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           fetch-depth: 2
           submodules: recursive
+      - run: sudo apt-get install -y libxml2-utils
       - name: Setup Node.js environment
         uses: actions/setup-node@v2
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7038,14 +7038,16 @@
       "link": true
     },
     "node_modules/jats-xml": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-0.0.14.tgz",
-      "integrity": "sha512-roqL4LcDs6JoFOWJ7rFBckyO1iN02E4WitYEXCv6ivQqUBF2fxDYxQBT0vDxLmIu2Gm05XtX2o0f7dGkcuzBHg==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-0.0.16.tgz",
+      "integrity": "sha512-dHaoNjrebbYIoVu7jh8mzVCh2jWXgReOJO1MCAcMqzsKcys9svXPHszg8+TsYNlIBkv4R6H6lVUp1WPKtb9P4Q==",
       "dependencies": {
         "fair-principles": "^1.0.3",
         "node-fetch": "^2.6.7",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.0",
+        "unzipper": "^0.10.11",
+        "which": "^2.0.2",
         "xml-js": "^1.6.11"
       },
       "bin": {
@@ -13033,7 +13035,7 @@
       "version": "0.0.24",
       "license": "MIT",
       "dependencies": {
-        "jats-xml": "^0.0.14",
+        "jats-xml": "^0.0.16",
         "myst-common": "^0.0.16",
         "myst-frontmatter": "^0.0.12",
         "myst-spec": "^0.0.4",
@@ -13728,7 +13730,7 @@
       "license": "MIT",
       "dependencies": {
         "citation-js-utils": "^0.0.15",
-        "jats-xml": "^0.0.14",
+        "jats-xml": "^0.0.16",
         "myst-common": "^0.0.16",
         "myst-frontmatter": "^0.0.12",
         "myst-spec": "^0.0.4",
@@ -18820,7 +18822,7 @@
       "version": "file:packages/jats-to-myst",
       "requires": {
         "@types/jest": "^28.1.6",
-        "jats-xml": "^0.0.14",
+        "jats-xml": "^0.0.16",
         "jest": "^28.1.3",
         "myst-common": "^0.0.16",
         "myst-frontmatter": "^0.0.12",
@@ -18838,14 +18840,16 @@
       }
     },
     "jats-xml": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-0.0.14.tgz",
-      "integrity": "sha512-roqL4LcDs6JoFOWJ7rFBckyO1iN02E4WitYEXCv6ivQqUBF2fxDYxQBT0vDxLmIu2Gm05XtX2o0f7dGkcuzBHg==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-0.0.16.tgz",
+      "integrity": "sha512-dHaoNjrebbYIoVu7jh8mzVCh2jWXgReOJO1MCAcMqzsKcys9svXPHszg8+TsYNlIBkv4R6H6lVUp1WPKtb9P4Q==",
       "requires": {
         "fair-principles": "^1.0.3",
         "node-fetch": "^2.6.7",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.0",
+        "unzipper": "^0.10.11",
+        "which": "^2.0.2",
         "xml-js": "^1.6.11"
       }
     },
@@ -20735,7 +20739,7 @@
       "requires": {
         "@types/jest": "^28.1.6",
         "citation-js-utils": "^0.0.15",
-        "jats-xml": "^0.0.14",
+        "jats-xml": "^0.0.16",
         "jest": "^28.1.3",
         "myst-common": "^0.0.16",
         "myst-frontmatter": "^0.0.12",

--- a/packages/jats-to-myst/package.json
+++ b/packages/jats-to-myst/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/executablebooks/mystjs/issues"
   },
   "dependencies": {
-    "jats-xml": "^0.0.14",
+    "jats-xml": "^0.0.16",
     "myst-common": "^0.0.16",
     "myst-frontmatter": "^0.0.12",
     "myst-spec": "^0.0.4",

--- a/packages/myst-cli/tests/outputs/basic-md-and-config.xml
+++ b/packages/myst-cli/tests/outputs/basic-md-and-config.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
   <front>
     <article-meta>

--- a/packages/myst-to-jats/package.json
+++ b/packages/myst-to-jats/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "citation-js-utils": "^0.0.15",
-    "jats-xml": "^0.0.14",
+    "jats-xml": "^0.0.16",
     "myst-common": "^0.0.16",
     "myst-frontmatter": "^0.0.12",
     "myst-spec": "^0.0.4",

--- a/packages/myst-to-jats/src/backmatter.ts
+++ b/packages/myst-to-jats/src/backmatter.ts
@@ -38,13 +38,6 @@ export function citeToJatsRef(key: string, data: CitationJson): Element {
       elements: authors,
     });
   }
-  if (data.title) {
-    elements.push({
-      type: 'element',
-      name: 'article-title',
-      elements: [{ type: 'text', text: data.title }],
-    });
-  }
   if (data['container-title']) {
     elements.push({
       type: 'element',
@@ -105,6 +98,15 @@ export function citeToJatsRef(key: string, data: CitationJson): Element {
       type: 'element',
       name: 'issn',
       elements: [{ type: 'text', text: data.ISSN }],
+    });
+  }
+  // <element-citation> must have at least one child element to pass validation
+  // This ensures that if the citation is totally empty, it is given an empty title.
+  if (data.title || elements.length === 0) {
+    elements.unshift({
+      type: 'element',
+      name: 'article-title',
+      elements: data.title ? [{ type: 'text', text: data.title }] : [],
     });
   }
   return {

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -60,15 +60,13 @@ export function getArticleTitle(frontmatter: ProjectFrontmatter): Element[] {
   const title = frontmatter?.title;
   const subtitle = frontmatter?.subtitle;
   if (!title && !subtitle) return [];
-  const articleTitle: Element[] = title
-    ? [
-        {
-          type: 'element',
-          name: 'article-title',
-          elements: [{ type: 'text', text: title }],
-        },
-      ]
-    : [];
+  const articleTitle: Element[] = [
+    {
+      type: 'element',
+      name: 'article-title',
+      elements: title ? [{ type: 'text', text: title }] : [],
+    },
+  ];
   const articleSubtitle: Element[] = subtitle
     ? [
         {
@@ -162,7 +160,7 @@ export function getArticleAuthors(frontmatter: ProjectFrontmatter): Element[] {
     }
     return { type: 'element', name: 'contrib', attributes, elements };
   });
-  return contribs ?? [];
+  return contribs ? [{ type: 'element', name: 'contrib-group', elements: contribs }] : [];
 }
 
 export function getArticlePermissions(frontmatter: ProjectFrontmatter): Element[] {
@@ -229,52 +227,57 @@ export function getArticlePages(frontmatter: ProjectFrontmatter): Element[] {
   return pages;
 }
 
-export function getArticleMeta(frontmatter: ProjectFrontmatter): Element | null {
-  const elements = [
-    // article-id
-    // article-version, article-version-alternatives
-    // article-categories
-    ...getArticleTitle(frontmatter),
-    ...getArticleAuthors(frontmatter),
-    // author-notes
-    // pub-date or pub-date-not-available
-    ...getArticleVolume(frontmatter),
-    // volume-id
-    // volume-series
-    ...getArticleIssue(frontmatter),
-    // issue-id
-    // issue-title
-    // issue-title-group
-    // issue-sponsor
-    // issue-part
-    // volume-issue-group
-    // isbn
-    // supplement
-    ...getArticlePages(frontmatter),
-    // email, ext-link, uri, product, supplementary-material
-    // history
-    // pub-history
-    ...getArticlePermissions(frontmatter),
-    // self-uri
-    // related-article, related-object
-    // abstract
-    // trans-abstract
-    // kwd-group
-    // funding-group
-    // support-group
-    // conference
-    // counts
-  ];
-  return elements.length ? { type: 'element', name: 'article-meta', elements } : null;
+export function getArticleMeta(frontmatter?: ProjectFrontmatter): Element {
+  const elements = frontmatter
+    ? [
+        // article-id
+        // article-version, article-version-alternatives
+        // article-categories
+        ...getArticleTitle(frontmatter),
+        ...getArticleAuthors(frontmatter),
+        // author-notes
+        // pub-date or pub-date-not-available
+        ...getArticleVolume(frontmatter),
+        // volume-id
+        // volume-series
+        ...getArticleIssue(frontmatter),
+        // issue-id
+        // issue-title
+        // issue-title-group
+        // issue-sponsor
+        // issue-part
+        // volume-issue-group
+        // isbn
+        // supplement
+        ...getArticlePages(frontmatter),
+        // email, ext-link, uri, product, supplementary-material
+        // history
+        // pub-history
+        ...getArticlePermissions(frontmatter),
+        // self-uri
+        // related-article, related-object
+        // abstract
+        // trans-abstract
+        // kwd-group
+        // funding-group
+        // support-group
+        // conference
+        // counts
+      ]
+    : [];
+  return { type: 'element', name: 'article-meta', elements };
 }
 
+/**
+ * Get <front> JATS element
+ *
+ * This element must be defined in a JATS article and must include <article-meta>
+ */
 export function getFront(frontmatter?: ProjectFrontmatter): Element[] {
-  if (!frontmatter) return [];
   const elements: Element[] = [];
   const journalMeta = getJournalMeta();
   if (journalMeta) elements.push(journalMeta);
   const articleMeta = getArticleMeta(frontmatter);
-  if (articleMeta) elements.push(articleMeta);
-  if (!elements.length) return [];
+  elements.push(articleMeta);
   return [{ type: 'element', name: 'front', elements }];
 }

--- a/packages/myst-to-jats/src/frontmatter.ts
+++ b/packages/myst-to-jats/src/frontmatter.ts
@@ -160,7 +160,7 @@ export function getArticleAuthors(frontmatter: ProjectFrontmatter): Element[] {
     }
     return { type: 'element', name: 'contrib', attributes, elements };
   });
-  return contribs ? [{ type: 'element', name: 'contrib-group', elements: contribs }] : [];
+  return contribs?.length ? [{ type: 'element', name: 'contrib-group', elements: contribs }] : [];
 }
 
 export function getArticlePermissions(frontmatter: ProjectFrontmatter): Element[] {

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -479,10 +479,15 @@ export function writeJats(file: VFile, content: ArticleContent, opts?: DocumentO
   const element = opts?.fullArticle
     ? {
         type: 'element',
-        elements: [doc.article()],
-        declaration: opts?.fullArticle
-          ? { attributes: { version: '1.0', encoding: 'UTF-8' } }
-          : undefined,
+        elements: [
+          {
+            type: 'doctype',
+            doctype:
+              'article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd"',
+          },
+          doc.article(),
+        ],
+        declaration: { attributes: { version: '1.0', encoding: 'UTF-8' } },
       }
     : doc.body();
   const jats = js2xml(element, {

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -476,7 +476,15 @@ export class JatsDocument {
 
 export function writeJats(file: VFile, content: ArticleContent, opts?: DocumentOptions) {
   const doc = new JatsDocument(file, content, opts ?? { handlers });
-  const element = opts?.fullArticle ? { type: 'element', elements: [doc.article()] } : doc.body();
+  const element = opts?.fullArticle
+    ? {
+        type: 'element',
+        elements: [doc.article()],
+        declaration: opts?.fullArticle
+          ? { attributes: { version: '1.0', encoding: 'UTF-8' } }
+          : undefined,
+      }
+    : doc.body();
   const jats = js2xml(element, {
     compact: false,
     spaces: opts?.spaces,

--- a/packages/myst-to-jats/tests/article.yml
+++ b/packages/myst-to-jats/tests/article.yml
@@ -8,6 +8,7 @@ cases:
             - type: text
               value: text
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>text</p>
@@ -24,6 +25,7 @@ cases:
     frontmatter:
       title: Hello title!
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -47,6 +49,7 @@ cases:
     frontmatter:
       subtitle: Hello subtitle!
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -74,6 +77,7 @@ cases:
         issue: 2
         volume: 1
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -100,6 +104,7 @@ cases:
         content:
           url: https://creativecommons.org/licenses/by/4.0
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -128,6 +133,7 @@ cases:
         content:
           url: https://creativecommons.org/licenses/by/4.0
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -166,6 +172,7 @@ cases:
           website: https://example.com
         - name: John Doe
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -212,6 +219,7 @@ cases:
               label: my-footnote
               identifier: my-footnote
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>text
@@ -249,6 +257,7 @@ cases:
                     - type: text
                       value: Doe, 2000
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>(
@@ -279,6 +288,7 @@ cases:
                     - type: text
                       value: Doe, 2000
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>
@@ -297,6 +307,7 @@ cases:
               label: Smith_2023
               identifier: smith_2023
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>

--- a/packages/myst-to-jats/tests/article.yml
+++ b/packages/myst-to-jats/tests/article.yml
@@ -11,6 +11,9 @@ cases:
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta/>
+        </front>
         <body>
           <p>text</p>
         </body>
@@ -57,6 +60,7 @@ cases:
         <front>
           <article-meta>
             <title-group>
+              <article-title/>
               <subtitle>Hello subtitle!</subtitle>
             </title-group>
           </article-meta>
@@ -183,23 +187,25 @@ cases:
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
-            <contrib contrib-type="author" corresp="yes">
-              <contrib-id contrib-id-type="orcid">abc-123</contrib-id>
-              <string-name>Jane Doe</string-name>
-              <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role 1">credit role 1</role>
-              <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role 2">credit role 2</role>
-              <aff>
-                <institution>University One</institution>
-              </aff>
-              <aff>
-                <institution>University Two</institution>
-              </aff>
-              <email>example@example.com</email>
-              <ext-link ext-link-type="uri" xlink:href="https://example.com">https://example.com</ext-link>
-            </contrib>
-            <contrib contrib-type="author">
-              <string-name>John Doe</string-name>
-            </contrib>
+            <contrib-group>
+              <contrib contrib-type="author" corresp="yes">
+                <contrib-id contrib-id-type="orcid">abc-123</contrib-id>
+                <string-name>Jane Doe</string-name>
+                <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role 1">credit role 1</role>
+                <role vocab="CRediT" vocab-identifier="http://credit.niso.org/" vocab-term="credit role 2">credit role 2</role>
+                <aff>
+                  <institution>University One</institution>
+                </aff>
+                <aff>
+                  <institution>University Two</institution>
+                </aff>
+                <email>example@example.com</email>
+                <ext-link ext-link-type="uri" xlink:href="https://example.com">https://example.com</ext-link>
+              </contrib>
+              <contrib contrib-type="author">
+                <string-name>John Doe</string-name>
+              </contrib>
+            </contrib-group>
           </article-meta>
         </front>
         <body>
@@ -229,6 +235,9 @@ cases:
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta/>
+        </front>
         <body>
           <p>text
             <xref ref-type="fn" rid="my-footnote"/>
@@ -242,87 +251,4 @@ cases:
             </fn>
           </fn-group>
         </back>
-      </article>
-  - title: Cite group - parenthetical
-    tree:
-      type: root
-      children:
-        - type: paragraph
-          children:
-            - type: citeGroup
-              kind: parenthetical
-              children:
-                - type: cite
-                  label: Smith_2023
-                  identifier: smith_2023
-                  children:
-                    - type: text
-                      value: Smith, 2023
-                - type: cite
-                  label: Doe_2000
-                  identifier: doe_2000
-                  children:
-                    - type: text
-                      value: Doe, 2000
-    jats: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
-      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
-        <body>
-          <p>(
-            <xref ref-type="bibr" rid="Smith_2023">Smith, 2023</xref>; 
-            <xref ref-type="bibr" rid="Doe_2000">Doe, 2000</xref>)
-          </p>
-        </body>
-      </article>
-  - title: Cite group - narrative
-    tree:
-      type: root
-      children:
-        - type: paragraph
-          children:
-            - type: citeGroup
-              kind: narrative
-              children:
-                - type: cite
-                  label: Smith_2023
-                  identifier: smith_2023
-                  children:
-                    - type: text
-                      value: Smith, 2023
-                - type: cite
-                  label: Doe_2000
-                  identifier: doe_2000
-                  children:
-                    - type: text
-                      value: Doe, 2000
-    jats: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
-      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
-        <body>
-          <p>
-            <xref ref-type="bibr" rid="Smith_2023">Smith, 2023</xref>, 
-            <xref ref-type="bibr" rid="Doe_2000">Doe, 2000</xref>
-          </p>
-        </body>
-      </article>
-  - title: Cite
-    tree:
-      type: root
-      children:
-        - type: paragraph
-          children:
-            - type: cite
-              label: Smith_2023
-              identifier: smith_2023
-    jats: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
-      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
-        <body>
-          <p>
-            <xref ref-type="bibr" rid="Smith_2023"/>
-          </p>
-        </body>
       </article>

--- a/packages/myst-to-jats/tests/article.yml
+++ b/packages/myst-to-jats/tests/article.yml
@@ -9,6 +9,7 @@ cases:
               value: text
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>text</p>
@@ -26,6 +27,7 @@ cases:
       title: Hello title!
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -50,6 +52,7 @@ cases:
       subtitle: Hello subtitle!
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -78,6 +81,7 @@ cases:
         volume: 1
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -105,6 +109,7 @@ cases:
           url: https://creativecommons.org/licenses/by/4.0
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -134,6 +139,7 @@ cases:
           url: https://creativecommons.org/licenses/by/4.0
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -173,6 +179,7 @@ cases:
         - name: John Doe
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>
@@ -220,6 +227,7 @@ cases:
               identifier: my-footnote
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>text
@@ -258,6 +266,7 @@ cases:
                       value: Doe, 2000
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>(
@@ -289,6 +298,7 @@ cases:
                       value: Doe, 2000
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>
@@ -308,6 +318,7 @@ cases:
               identifier: smith_2023
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>

--- a/packages/myst-to-jats/tests/citations.yml
+++ b/packages/myst-to-jats/tests/citations.yml
@@ -32,6 +32,7 @@ cases:
         cite: {}
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>text</p>

--- a/packages/myst-to-jats/tests/citations.yml
+++ b/packages/myst-to-jats/tests/citations.yml
@@ -34,6 +34,9 @@ cases:
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta/>
+        </front>
         <body>
           <p>text</p>
         </body>
@@ -41,6 +44,7 @@ cases:
           <ref-list>
             <ref id="doe_2000">
               <element-citation publication-type="journal">
+                <article-title>My Title!</article-title>
                 <person-group person-group-type="author">
                   <name>
                     <surname>Doe</surname>
@@ -51,7 +55,6 @@ cases:
                     <given-names>John</given-names>
                   </name>
                 </person-group>
-                <article-title>My Title!</article-title>
                 <source>My Journal</source>
                 <year iso-8601-date="2000">2000</year>
                 <pub-id pub-id-type="doi">10.1000/example.1000</pub-id>
@@ -63,7 +66,151 @@ cases:
               </element-citation>
             </ref>
             <ref id="example_2020">
-              <element-citation publication-type="journal"/>
+              <element-citation publication-type="journal">
+                <article-title/>
+              </element-citation>
+            </ref>
+          </ref-list>
+        </back>
+      </article>
+  - title: Cite group - parenthetical
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: citeGroup
+              kind: parenthetical
+              children:
+                - type: cite
+                  label: Smith_2023
+                  identifier: smith_2023
+                  children:
+                    - type: text
+                      value: Smith, 2023
+                - type: cite
+                  label: Doe_2000
+                  identifier: doe_2000
+                  children:
+                    - type: text
+                      value: Doe, 2000
+    citations:
+      Smith_2023:
+        cite: {}
+      Doe_2000:
+        cite: {}
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta/>
+        </front>
+        <body>
+          <p>(
+            <xref ref-type="bibr" rid="Smith_2023">Smith, 2023</xref>; 
+            <xref ref-type="bibr" rid="Doe_2000">Doe, 2000</xref>)
+          </p>
+        </body>
+        <back>
+          <ref-list>
+            <ref id="Doe_2000">
+              <element-citation publication-type="journal">
+                <article-title/>
+              </element-citation>
+            </ref>
+            <ref id="Smith_2023">
+              <element-citation publication-type="journal">
+                <article-title/>
+              </element-citation>
+            </ref>
+          </ref-list>
+        </back>
+      </article>
+  - title: Cite group - narrative
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: citeGroup
+              kind: narrative
+              children:
+                - type: cite
+                  label: Smith_2023
+                  identifier: smith_2023
+                  children:
+                    - type: text
+                      value: Smith, 2023
+                - type: cite
+                  label: Doe_2000
+                  identifier: doe_2000
+                  children:
+                    - type: text
+                      value: Doe, 2000
+    citations:
+      Smith_2023:
+        cite: {}
+      Doe_2000:
+        cite: {}
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta/>
+        </front>
+        <body>
+          <p>
+            <xref ref-type="bibr" rid="Smith_2023">Smith, 2023</xref>, 
+            <xref ref-type="bibr" rid="Doe_2000">Doe, 2000</xref>
+          </p>
+        </body>
+        <back>
+          <ref-list>
+            <ref id="Doe_2000">
+              <element-citation publication-type="journal">
+                <article-title/>
+              </element-citation>
+            </ref>
+            <ref id="Smith_2023">
+              <element-citation publication-type="journal">
+                <article-title/>
+              </element-citation>
+            </ref>
+          </ref-list>
+        </back>
+      </article>
+  - title: Cite
+    tree:
+      type: root
+      children:
+        - type: paragraph
+          children:
+            - type: cite
+              label: Smith_2023
+              identifier: smith_2023
+    citations:
+      Smith_2023:
+        cite: {}
+    jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
+      <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta/>
+        </front>
+        <body>
+          <p>
+            <xref ref-type="bibr" rid="Smith_2023"/>
+          </p>
+        </body>
+        <back>
+          <ref-list>
+            <ref id="Smith_2023">
+              <element-citation publication-type="journal">
+                <article-title/>
+              </element-citation>
             </ref>
           </ref-list>
         </back>

--- a/packages/myst-to-jats/tests/citations.yml
+++ b/packages/myst-to-jats/tests/citations.yml
@@ -31,6 +31,7 @@ cases:
       example_2020:
         cite: {}
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>text</p>

--- a/packages/myst-to-jats/tests/multi.yml
+++ b/packages/myst-to-jats/tests/multi.yml
@@ -24,6 +24,7 @@ cases:
                   value: article 2
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>text</p>
@@ -76,6 +77,7 @@ cases:
                   value: article 2
     jats: |-
       <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>

--- a/packages/myst-to-jats/tests/multi.yml
+++ b/packages/myst-to-jats/tests/multi.yml
@@ -23,6 +23,7 @@ cases:
                 - type: text
                   value: article 2
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <body>
           <p>text</p>
@@ -74,6 +75,7 @@ cases:
                 - type: text
                   value: article 2
     jats: |-
+      <?xml version="1.0" encoding="UTF-8"?>
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
         <front>
           <article-meta>

--- a/packages/myst-to-jats/tests/multi.yml
+++ b/packages/myst-to-jats/tests/multi.yml
@@ -26,15 +26,20 @@ cases:
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3 20210610//EN" "http://jats.nlm.nih.gov/publishing/1.3/JATS-archivearticle1-3-mathml3.dtd">
       <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" dtd-version="1.3" xml:lang="en">
+        <front>
+          <article-meta/>
+        </front>
         <body>
           <p>text</p>
         </body>
         <sub-article>
+          <front-stub/>
           <body>
             <p>article 1</p>
           </body>
         </sub-article>
         <sub-article>
+          <front-stub/>
           <body>
             <p>article 2</p>
           </body>
@@ -92,18 +97,23 @@ cases:
         <back>
           <ref-list>
             <ref id="example_2020">
-              <element-citation publication-type="journal"/>
+              <element-citation publication-type="journal">
+                <article-title/>
+              </element-citation>
             </ref>
           </ref-list>
         </back>
         <sub-article>
+          <front-stub/>
           <body>
             <p>article 1</p>
           </body>
           <back>
             <ref-list>
               <ref id="example_2000">
-                <element-citation publication-type="journal"/>
+                <element-citation publication-type="journal">
+                  <article-title/>
+                </element-citation>
               </ref>
             </ref-list>
           </back>


### PR DESCRIPTION
This also fixes up a few instances of previously-invalid JATS XML including:
- `contrib-group` now wraps contribs
- `front` with `article-meta` is always present
- `element-citations` are never empty

Also this PR adds XML declaration and doctype headers.