### PR TITLE
🧮 Inline user_expression support

### DIFF
--- a/.changeset/cyan-rice-burn.md
+++ b/.changeset/cyan-rice-burn.md
@@ -1,0 +1,8 @@
+---
+'myst-cli': patch
+'myst-roles': patch
+'myst-spec-ext': patch
+'myst-to-jats': patch
+---
+
+Add inline evaluation role that pulls from user_expressions

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -44,6 +44,7 @@ import {
   transformImageFormats,
   transformThumbnail,
   StaticFileTransformer,
+  inlineExpressionsPlugin,
 } from '../transforms';
 import type { ImageExtensions } from '../utils';
 import { logMessagesFromVFile } from '../utils';
@@ -128,6 +129,7 @@ export async function transformMdast(
 
   await unified()
     .use(basicTransformationsPlugin)
+    .use(inlineExpressionsPlugin) // Happens before math and images!
     .use(htmlPlugin, { htmlHandlers })
     .use(mathPlugin, { macros: frontmatter.math })
     .use(enumerateTargetsPlugin, { state }) // This should be after math

--- a/packages/myst-cli/src/transforms/index.ts
+++ b/packages/myst-cli/src/transforms/index.ts
@@ -7,4 +7,5 @@ export * from './include';
 export * from './links';
 export * from './mdast';
 export * from './outputs';
+export * from './inlineExpressions';
 export * from './types';

--- a/packages/myst-cli/src/transforms/inlineExpressions.ts
+++ b/packages/myst-cli/src/transforms/inlineExpressions.ts
@@ -1,0 +1,93 @@
+import type { GenericNode } from 'myst-common';
+import { fileWarn, NotebookCell } from 'myst-common';
+import { selectAll } from 'unist-util-select';
+import type { Root } from 'mdast';
+import type { InlineExpression } from 'myst-spec-ext';
+import type { StaticPhrasingContent } from 'myst-spec';
+import type { Plugin } from 'unified';
+import type { VFile } from 'vfile';
+
+export const metadataSection = 'user_expressions';
+
+export interface IBaseExpressionResult {
+  status: string;
+}
+
+export interface IExpressionOutput extends IBaseExpressionResult {
+  status: 'ok';
+  data: Record<string, string>;
+  metadata: Record<string, string>;
+}
+
+export interface IExpressionError extends IBaseExpressionResult {
+  status: 'error';
+  traceback: string[];
+  ename: string;
+  evalue: string;
+}
+
+export type IExpressionResult = IExpressionError | IExpressionOutput;
+
+export interface IUserExpressionMetadata {
+  expression: string;
+  result: IExpressionResult;
+}
+
+export interface IUserExpressionsMetadata {
+  [metadataSection]: IUserExpressionMetadata[];
+}
+
+function findExpression(
+  expressions: IUserExpressionMetadata[],
+  value: string,
+): IUserExpressionMetadata | undefined {
+  return expressions.find((expr) => expr.expression === value);
+}
+
+function processLatex(value: string) {
+  return value
+    .trim()
+    .replace(/^\$(\\displaystyle)?/, '')
+    .replace(/\$$/, '')
+    .trim();
+}
+
+function renderExpression(node: InlineExpression, file: VFile): StaticPhrasingContent[] {
+  const result = node.result as IExpressionResult;
+  if (!result) return [];
+  if (result.status === 'ok') {
+    if (result.data['text/latex']) {
+      return [{ type: 'inlineMath', value: processLatex(result.data['text/latex']) }];
+    }
+    if (result.data['text/plain']) {
+      return [{ type: 'text', value: result.data['text/plain'] }];
+    }
+    fileWarn(file, 'Unrecognized mime bundle for inline content', { node });
+  }
+  return [];
+}
+
+export function transformInlineExpressions(mdast: Root, file: VFile) {
+  const blocks = selectAll('block', mdast).filter(
+    (node) => node.data?.type === NotebookCell.content && node.data?.[metadataSection],
+  ) as GenericNode[];
+
+  let count = 0;
+
+  blocks.forEach((node) => {
+    const userExpressions = node.data?.[metadataSection] as IUserExpressionMetadata[];
+    const inlineNodes = selectAll('inlineExpression', node) as InlineExpression[];
+    inlineNodes.forEach((inlineExpression) => {
+      const data = findExpression(userExpressions, inlineExpression.value);
+      if (!data) return;
+      count += 1;
+      inlineExpression.identifier = `eval-${count}`;
+      inlineExpression.result = data.result;
+      inlineExpression.children = renderExpression(inlineExpression, file);
+    });
+  });
+}
+
+export const inlineExpressionsPlugin: Plugin<[], Root, Root> = () => (tree, file) => {
+  transformInlineExpressions(tree, file);
+};

--- a/packages/myst-roles/src/index.ts
+++ b/packages/myst-roles/src/index.ts
@@ -5,6 +5,7 @@ import { deleteRole } from './delete';
 import { mathRole } from './math';
 import { refRole } from './reference';
 import { siRole } from './si';
+import { evalRole } from './inlineExpression';
 import { smallcapsRole } from './smallcaps';
 import { subscriptRole } from './subscript';
 import { superscriptRole } from './superscript';
@@ -18,6 +19,7 @@ export const defaultRoles = [
   mathRole,
   refRole,
   siRole,
+  evalRole,
   smallcapsRole,
   subscriptRole,
   superscriptRole,

--- a/packages/myst-roles/src/inlineExpression.ts
+++ b/packages/myst-roles/src/inlineExpression.ts
@@ -1,0 +1,19 @@
+import type { InlineExpression } from 'myst-spec-ext';
+import type { RoleSpec, RoleData, GenericNode } from 'myst-common';
+import { ParseTypesEnum } from 'myst-common';
+
+export const evalRole: RoleSpec = {
+  name: 'eval',
+  body: {
+    type: ParseTypesEnum.string,
+    required: true,
+  },
+  run(data: RoleData): GenericNode[] {
+    const value = data.body as string;
+    const node: InlineExpression = {
+      type: 'inlineExpression',
+      value,
+    };
+    return [node];
+  },
+};

--- a/packages/myst-spec-ext/src/types.ts
+++ b/packages/myst-spec-ext/src/types.ts
@@ -101,3 +101,11 @@ export type SiUnit = {
   alt?: string;
   value: string;
 };
+
+export type InlineExpression = {
+  type: 'inlineExpression';
+  value: string;
+  identifier?: string;
+  result?: Record<string, any>;
+  children?: StaticPhrasingContent[];
+};

--- a/packages/myst-to-jats/src/backmatter.ts
+++ b/packages/myst-to-jats/src/backmatter.ts
@@ -139,10 +139,31 @@ export function getFootnotes(footnotes?: Element[]): Element[] {
   return [{ type: 'element', name: 'fn-group', elements: footnotes }];
 }
 
-export function getBack(citations?: CitationRenderer, footnotes?: Element[]): Element[] {
+export function getExpressions(expressions?: Element[]): Element[] {
+  if (!expressions?.length) return [];
+  return [
+    {
+      type: 'element',
+      name: 'notes',
+      attributes: { 'notes-type': 'expressions' },
+      elements: expressions,
+    },
+  ];
+}
+
+export function getBack({
+  citations,
+  footnotes,
+  expressions,
+}: {
+  citations?: CitationRenderer;
+  footnotes?: Element[];
+  expressions?: Element[];
+}): Element[] {
   const elements = [
     ...getRefList(citations),
     ...getFootnotes(footnotes),
+    ...getExpressions(expressions),
     // ack
     // app-group
     // bio

--- a/packages/myst-to-jats/src/inlineExpression.ts
+++ b/packages/myst-to-jats/src/inlineExpression.ts
@@ -1,0 +1,46 @@
+import type { InlineExpression } from 'myst-spec-ext';
+import type { Element, Handler, IJatsSerializer } from './types';
+import type { GenericNode } from 'myst-common';
+
+function renderMimeToJats(state: IJatsSerializer, node: GenericNode): Element[] {
+  const { result } = node as InlineExpression;
+  return Object.entries(result?.data ?? {}).map(([key, value]): Element => {
+    switch (key) {
+      case 'text/plain':
+        return { type: 'text', text: value as string };
+      default:
+        state.error(`Unknown inline render target of type ${key}`, node);
+        return { type: 'text', text: 'Unknown Inline Expression' };
+    }
+  });
+}
+
+export const inlineExpression: Handler = (node, state) => {
+  const { identifier, value, result } = node as InlineExpression;
+  state.renderInline(node, 'xref', {
+    'ref-type': 'custom',
+    'custom-type': 'expression',
+    rid: identifier,
+  });
+  const element = {
+    type: 'element',
+    name: 'sec',
+    attributes: { id: identifier, 'sec-type': 'expression' },
+    elements: [
+      {
+        type: 'element',
+        name: 'code',
+        attributes: { executable: 'yes' },
+        elements: [{ type: 'text', text: value }],
+      },
+      {
+        type: 'element',
+        name: 'sec',
+        attributes: { 'sec-type': 'notebook-output' },
+        elements: [{ type: 'element', name: 'p', elements: [{ type: 'text', text: value }] }],
+      },
+    ],
+  } as Element;
+  state.warn('JATS representations of inline expressions is not complete', node);
+  if (element) state.expressions.push(element);
+};

--- a/packages/myst-to-jats/src/inlineExpression.ts
+++ b/packages/myst-to-jats/src/inlineExpression.ts
@@ -1,22 +1,21 @@
 import type { InlineExpression } from 'myst-spec-ext';
-import type { Element, Handler, IJatsSerializer } from './types';
-import type { GenericNode } from 'myst-common';
+import type { Element, Handler } from './types';
 
-function renderMimeToJats(state: IJatsSerializer, node: GenericNode): Element[] {
-  const { result } = node as InlineExpression;
-  return Object.entries(result?.data ?? {}).map(([key, value]): Element => {
-    switch (key) {
-      case 'text/plain':
-        return { type: 'text', text: value as string };
-      default:
-        state.error(`Unknown inline render target of type ${key}`, node);
-        return { type: 'text', text: 'Unknown Inline Expression' };
-    }
-  });
-}
+// function renderMimeToJats(state: IJatsSerializer, node: GenericNode): Element[] {
+//   const { result } = node as InlineExpression;
+//   return Object.entries(result?.data ?? {}).map(([key, value]): Element => {
+//     switch (key) {
+//       case 'text/plain':
+//         return { type: 'text', text: value as string };
+//       default:
+//         state.error(`Unknown inline render target of type ${key}`, node);
+//         return { type: 'text', text: 'Unknown Inline Expression' };
+//     }
+//   });
+// }
 
 export const inlineExpression: Handler = (node, state) => {
-  const { identifier, value, result } = node as InlineExpression;
+  const { identifier, value } = node as InlineExpression;
   state.renderInline(node, 'xref', {
     'ref-type': 'custom',
     'custom-type': 'expression',

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -43,6 +43,7 @@ export interface IJatsSerializer<D extends Record<string, any> = StateData> {
   data: D;
   stack: Element[];
   footnotes: Element[];
+  expressions: Element[];
   text: (value?: string) => void;
   renderChildren: (node: any) => void;
   renderInline: (node: GenericNode, name: string, attributes?: Attributes) => void;


### PR DESCRIPTION
This supports the eval role in jupyterlab_myst in the CLI and exporting out to formats like JATS, docx, tex, and word for a subset of mimetypes. Lots of work still to expand support for other mimetypes, but a good start!

![image](https://user-images.githubusercontent.com/913249/234689919-b71f8483-9937-43df-975b-a23797fad556.png)
