### PR TITLE
⚡️ Remove _static folder; keep site assets flat in public folder

### DIFF
--- a/.changeset/loud-lobsters-marry.md
+++ b/.changeset/loud-lobsters-marry.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Keep all static site assets in public folder, no \_static

--- a/packages/myst-cli/src/build/site/prepare.ts
+++ b/packages/myst-cli/src/build/site/prepare.ts
@@ -30,7 +30,7 @@ export function cleanSiteContent(session: ISession, info = true): void {
 export function ensureBuildFoldersExist(session: ISession): void {
   // This also creates the site directory!
   fs.mkdirSync(session.contentPath(), { recursive: true });
-  fs.mkdirSync(session.staticPath(), { recursive: true });
+  fs.mkdirSync(session.publicPath(), { recursive: true });
   session.log.debug(`Build folders created for site content: ${session.sitePath()}`);
 }
 

--- a/packages/myst-cli/src/process/site.ts
+++ b/packages/myst-cli/src/process/site.ts
@@ -220,8 +220,8 @@ export async function fastProcessFile(
   await loadFile(session, file);
   await transformMdast(session, {
     file,
-    imageWriteFolder: session.staticPath(),
-    imageAltOutputFolder: '/_static/',
+    imageWriteFolder: session.publicPath(),
+    imageAltOutputFolder: '/',
     imageExtensions: WEB_IMAGE_EXTENSIONS,
     projectPath,
     projectSlug,
@@ -295,7 +295,7 @@ export async function processProject(
     pages.map((page) =>
       transformMdast(session, {
         file: page.file,
-        imageWriteFolder: imageWriteFolder ?? session.staticPath(),
+        imageWriteFolder: imageWriteFolder ?? session.publicPath(),
         imageAltOutputFolder,
         imageExtensions: imageExtensions ?? WEB_IMAGE_EXTENSIONS,
         projectPath: project.path,
@@ -357,8 +357,8 @@ export async function processSite(session: ISession, opts?: ProcessOptions): Pro
     siteConfig.projects.map((siteProject) =>
       processProject(session, siteProject, {
         ...opts,
-        imageWriteFolder: session.staticPath(),
-        imageAltOutputFolder: '/_static/',
+        imageWriteFolder: session.publicPath(),
+        imageAltOutputFolder: '/',
       }),
     ),
   );

--- a/packages/myst-cli/src/session/session.ts
+++ b/packages/myst-cli/src/session/session.ts
@@ -63,10 +63,6 @@ export class Session implements ISession {
     return path.join(this.sitePath(), 'public');
   }
 
-  staticPath(): string {
-    return path.join(this.publicPath(), '_static');
-  }
-
   clone(): Session {
     return new Session({ logger: this.log });
   }

--- a/packages/myst-cli/src/session/types.ts
+++ b/packages/myst-cli/src/session/types.ts
@@ -19,7 +19,6 @@ export type ISession = {
   sitePath(): string;
   contentPath(): string;
   publicPath(): string;
-  staticPath(): string;
 };
 
 export type ISessionWithCache = ISession & {

--- a/packages/myst-cli/src/transforms/links.ts
+++ b/packages/myst-cli/src/transforms/links.ts
@@ -139,7 +139,7 @@ export class StaticFileTransformer implements LinkTransformer {
       link.internal = true;
     } else {
       // Copy relative file to static folder and replace with absolute link
-      const copiedFile = hashAndCopyStaticFile(this.session, linkFile, this.session.staticPath());
+      const copiedFile = hashAndCopyStaticFile(this.session, linkFile, this.session.publicPath());
       if (!copiedFile) {
         fileError(file, `Error copying file ${urlSource}`, {
           node: link,
@@ -147,7 +147,7 @@ export class StaticFileTransformer implements LinkTransformer {
         });
         return false;
       }
-      link.url = `/_static/${copiedFile}`;
+      link.url = `/${copiedFile}`;
       link.static = true;
     }
     updateLinkTextIfEmpty(link, title || path.basename(linkFile));


### PR DESCRIPTION
Removing this nesting is one step towards exporting static HTML: https://github.com/executablebooks/mystjs/issues/188