### PR TITLE
🌃 Update images for capturing nested layers

### DIFF
--- a/.changeset/gentle-trains-raise.md
+++ b/.changeset/gentle-trains-raise.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Improve the imagemagik command for layered EPS export


### PR DESCRIPTION
This fixes some oddities in dealing with imagemagik for layered graphics. Here we only take the first layer. I saw this mostly in working with EPS files from authors.