### PR TITLE
🤖 Better reading of frontmatter in JupyterBook

### DIFF
--- a/.changeset/silver-toys-collect.md
+++ b/.changeset/silver-toys-collect.md
@@ -1,0 +1,6 @@
+---
+'myst-cli': patch
+'myst-transforms': patch
+---
+
+Pick up frontmatter title that has a label/target node in front of it.

--- a/packages/myst-cli/src/frontmatter.ts
+++ b/packages/myst-cli/src/frontmatter.ts
@@ -34,6 +34,7 @@ export function getPageFrontmatter(
   const { frontmatter: rawPageFrontmatter } = getFrontmatter(tree, {
     removeYaml: removeNode,
     removeHeading: removeNode,
+    propagateTargets: true,
   });
   unnestKernelSpec(rawPageFrontmatter);
   const pageFrontmatter = validatePageFrontmatter(rawPageFrontmatter, {

--- a/packages/myst-transforms/src/frontmatter.ts
+++ b/packages/myst-transforms/src/frontmatter.ts
@@ -1,19 +1,26 @@
 import yaml from 'js-yaml';
-import { select } from 'unist-util-select';
 import { remove } from 'unist-util-remove';
 import type { Root } from 'mdast';
 import type { Block, Code, Heading } from 'myst-spec';
 import { toText } from 'myst-common';
+import { mystTargetsTransform } from './targets';
 
 type Options = {
   removeYaml?: boolean;
   removeHeading?: boolean;
+  /**
+   * In many existing JupyterBooks, the first node is a label `(heading)=`
+   * The `propagateTargets` option merges the target with the heading
+   * so the title can be picked up by the frontmatter.
+   */
+  propagateTargets?: boolean;
 };
 
 export function getFrontmatter(
   tree: Root,
-  opts: Options = { removeYaml: true, removeHeading: true },
+  opts: Options = { removeYaml: true, removeHeading: true, propagateTargets: true },
 ): { tree: Root; frontmatter: Record<string, any> } {
+  if (opts.propagateTargets) mystTargetsTransform(tree);
   const firstParent =
     (tree.children[0]?.type as any) === 'block' ? (tree.children[0] as any as Block) : tree;
   const firstNode = firstParent.children?.[0] as Code;


### PR DESCRIPTION
Before:
![image](https://github.com/executablebooks/mystjs/assets/913249/277a32de-45ee-4f62-8d72-31412a3ccc6b)

After:
![image](https://github.com/executablebooks/mystjs/assets/913249/3f829d23-0cc1-4ab9-8ccf-9baee3fdc406)
