### PR TITLE
🌉 Allow for multiple images in a single figure

### DIFF
--- a/.changeset/fluffy-countries-search.md
+++ b/.changeset/fluffy-countries-search.md
@@ -1,0 +1,5 @@
+---
+'myst-directives': patch
+---
+
+Allow for multiple images to be included in a single figure directive

--- a/packages/myst-directives/src/figure.ts
+++ b/packages/myst-directives/src/figure.ts
@@ -62,7 +62,13 @@ export const figureDirective: DirectiveSpec = {
     };
     const children: GenericNode[] = [img];
     if (data.body) {
-      const [caption, ...legend] = data.body as GenericNode[];
+      // TODO: This is probably better as a transform in the future
+      const nodes = data.body as GenericNode[];
+      // Allow multiple images to be added before a caption
+      const firstNonImage = nodes.findIndex(({ type }) => type !== 'image');
+      const images = nodes.slice(0, firstNonImage);
+      children.push(...images);
+      const [caption, ...legend] = nodes.slice(firstNonImage);
       if (caption) {
         children.push({ type: 'caption', children: [caption] });
       }


### PR DESCRIPTION
This is a step towards better sub-figure support. Currently you can add a figure that now includes images as the first-children of the directive, this will skip putting those as the caption, and look for non-image nodes for the caption.