### PR TITLE
💬 Remove `mystComment` in favour of `comment`

### DIFF
--- a/packages/jats-to-myst/src/index.ts
+++ b/packages/jats-to-myst/src/index.ts
@@ -108,7 +108,7 @@ const handlers: Record<string, Handler> = {
   // mystDirective(node, state) {
   //   state.renderChildren(node);
   // },
-  // mystComment() {
+  // comment() {
   //   // Do not archive comments
   // },
   bold(node, state) {

--- a/packages/myst-parser/src/tokensToMyst.ts
+++ b/packages/myst-parser/src/tokensToMyst.ts
@@ -434,7 +434,7 @@ const defaultMdast: Record<string, TokenHandlerSpec> = {
     },
   },
   myst_line_comment: {
-    type: 'mystComment',
+    type: 'comment',
     noCloseToken: true,
     isLeaf: true,
     getAttrs(t) {

--- a/packages/myst-parser/tests/myst.spec.ts
+++ b/packages/myst-parser/tests/myst.spec.ts
@@ -5,6 +5,7 @@ import { visit } from 'unist-util-visit';
 import type { Root } from 'mdast';
 import { mystParse } from '../src';
 import { mystToHtml } from 'myst-to-html';
+import { selectAll } from 'unist-util-select';
 
 type TestFile = {
   cases: TestCase[];
@@ -81,21 +82,41 @@ function stripPositions(tree: Root) {
   return tree;
 }
 
+function replaceMystCommentNodes(tree: Root) {
+  selectAll('comment', tree).forEach((node) => {
+    // In a future version of the spec, hopefully this is removed
+    // There isn't anything myst-like about the comments
+    node.type = 'mystComment';
+  });
+  return tree;
+}
+
+function replaceCommentNodes(tree: Root) {
+  selectAll('mystComment', tree).forEach((node) => {
+    // In a future version of the spec, hopefully this is removed
+    // There isn't anything myst-like about the comments
+    node.type = 'comment';
+  });
+  return tree;
+}
+
 describe('Testing myst --> mdast conversions', () => {
   test.each(mystCases)('%s', (_, { myst, mdast }) => {
     if (myst) {
       const mdastString = yaml.dump(mdast);
       const newAst = yaml.dump(
-        stripPositions(
-          mystParse(myst, {
-            mdast: {
-              hoistSingleImagesOutofParagraphs: false,
-              nestBlocks: false,
-            },
-            extensions: {
-              frontmatter: false, // Frontmatter screws with some tests!
-            },
-          }),
+        replaceMystCommentNodes(
+          stripPositions(
+            mystParse(myst, {
+              mdast: {
+                hoistSingleImagesOutofParagraphs: false,
+                nestBlocks: false,
+              },
+              extensions: {
+                frontmatter: false, // Frontmatter screws with some tests!
+              },
+            }),
+          ),
         ),
       );
       if (newAst.includes('startingLineNumber: 2')) {
@@ -110,9 +131,10 @@ describe('Testing myst --> mdast conversions', () => {
 
 describe('Testing mdast --> html conversions', () => {
   test.each(htmlCases)('%s', (name, { html, mdast }) => {
+    const modified = replaceCommentNodes(mdast);
     if (html) {
       if (name.includes('cmark_spec_0.30')) {
-        const output = mystToHtml(mdast, {
+        const output = mystToHtml(modified, {
           formatHtml: false,
           hast: {
             clobberPrefix: 'm-',
@@ -138,7 +160,7 @@ describe('Testing mdast --> html conversions', () => {
 
         expect(normalize(o)).toEqual(normalize(i));
       } else {
-        const newHTML = mystToHtml(mdast, {
+        const newHTML = mystToHtml(modified, {
           formatHtml: true,
           hast: {
             clobberPrefix: 'm-',

--- a/packages/myst-to-docx/src/schema.ts
+++ b/packages/myst-to-docx/src/schema.ts
@@ -511,11 +511,6 @@ const include: Handler<{ type: 'include' } & Parent> = (state, node) => {
   state.renderChildren(node);
 };
 
-const mystComment: Handler<{ type: 'mystComment' } & Parent> = () => {
-  // Do nothing!
-  return;
-};
-
 const comment: Handler<{ type: 'comment' } & Parent> = () => {
   // Do nothing!
   return;
@@ -551,7 +546,6 @@ export const defaultHandlers = {
   code,
   image,
   block,
-  mystComment,
   comment,
   mystDirective,
   mystRole,

--- a/packages/myst-to-html/src/schema.ts
+++ b/packages/myst-to-html/src/schema.ts
@@ -107,7 +107,7 @@ const mystDirective: Handler = (h, node) => {
 const block: Handler = (h, node) =>
   h(node, 'div', { class: 'block', 'data-block': node.meta }, all(h, node));
 
-const mystComment: Handler = (h, node) => u('comment', node.value);
+const comment: Handler = (h, node) => u('comment', node.value);
 
 const heading: Handler = (h, node) =>
   h(node, `h${node.depth}`, { id: node.identifier || undefined }, all(h, node));
@@ -183,8 +183,7 @@ export const mystToHast: Plugin<[Options?], string, Root> = (opts) => (tree: Roo
       mystRole,
       mystDirective,
       block,
-      mystComment,
-      comment: mystComment,
+      comment,
       heading,
       crossReference,
       code,

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -191,9 +191,6 @@ const handlers: Record<string, Handler> = {
   mystDirective(node, state) {
     state.renderChildren(node);
   },
-  mystComment() {
-    // Do not archive comments
-  },
   comment() {
     // Do not archive comments
   },

--- a/packages/myst-to-md/src/misc.ts
+++ b/packages/myst-to-md/src/misc.ts
@@ -45,7 +45,6 @@ function definitionDescription(node: any, _: Parent, state: State, info: Info) {
 export const miscHandlers: Record<string, Handle> = {
   block,
   comment,
-  mystComment: comment,
   definitionList,
   definitionTerm,
   definitionDescription,

--- a/packages/myst-to-md/tests/misc.yml
+++ b/packages/myst-to-md/tests/misc.yml
@@ -1,6 +1,6 @@
 title: myst-to-md references
 cases:
-  - title: mystComment
+  - title: comment
     mdast:
       type: root
       children:
@@ -12,7 +12,7 @@ cases:
               children:
                 - type: text
                   value: markdown
-        - type: mystComment
+        - type: comment
           value: and a comment
     markdown: |-
       Some % *markdown*

--- a/packages/myst-to-tex/src/index.ts
+++ b/packages/myst-to-tex/src/index.ts
@@ -134,11 +134,6 @@ const handlers: Record<string, Handler> = {
   mystDirective(node, state) {
     state.renderChildren(node, false);
   },
-  mystComment(node, state) {
-    state.ensureNewLine();
-    state.write(`% ${node.value?.split('\n').join('\n% ') ?? ''}`);
-    state.closeBlock(node);
-  },
   comment(node, state) {
     state.ensureNewLine();
     state.write(`% ${node.value?.split('\n').join('\n% ') ?? ''}`);


### PR DESCRIPTION
In a future version of the spec, hopefully this is removed. There isn't anything myst-like about the comments.
    