### PR TITLE
📦 Move from `jats-xml` --> `jats-tags`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7052,17 +7052,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/jats-tags": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jats-tags/-/jats-tags-0.1.0.tgz",
+      "integrity": "sha512-kCL1fqhhWDLTGeA07y1O2xxlh2SN+4UvziF2BUSBEAWNzWSTgio7aaH1lK8WN1ajuMmqz+2/+zSlpVexVZUtwA=="
+    },
     "node_modules/jats-to-myst": {
       "resolved": "packages/jats-to-myst",
       "link": true
     },
     "node_modules/jats-xml": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-0.0.16.tgz",
-      "integrity": "sha512-dHaoNjrebbYIoVu7jh8mzVCh2jWXgReOJO1MCAcMqzsKcys9svXPHszg8+TsYNlIBkv4R6H6lVUp1WPKtb9P4Q==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-0.1.0.tgz",
+      "integrity": "sha512-G/VXaUJSAPj29cUjtOK/1j8WaqBMX0Dwo7afMS14lSjfcEbMub2w5OBJ+xGgHVQUA1ucNrKSonJVTCwyApUDtQ==",
       "dependencies": {
         "fair-principles": "^1.0.3",
+        "jats-tags": "^0.1.0",
+        "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.7",
+        "unist-util-is": "^5.2.1",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.0",
         "unzipper": "^0.10.11",
@@ -12321,8 +12329,12 @@
       }
     },
     "node_modules/unist-util-is": {
-      "version": "5.1.1",
-      "license": "MIT",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -13062,7 +13074,8 @@
       "version": "0.0.29",
       "license": "MIT",
       "dependencies": {
-        "jats-xml": "^0.0.16",
+        "jats-tags": "^0.1.0",
+        "jats-xml": "^0.1.0",
         "myst-common": "^0.0.17",
         "myst-frontmatter": "^0.0.13",
         "myst-spec": "^0.0.4",
@@ -13831,7 +13844,7 @@
       "license": "MIT",
       "dependencies": {
         "citation-js-utils": "^0.0.15",
-        "jats-xml": "^0.0.16",
+        "jats-tags": "^0.1.0",
         "myst-common": "^0.0.17",
         "myst-frontmatter": "^0.0.13",
         "myst-spec": "^0.0.4",
@@ -13846,6 +13859,7 @@
         "@types/jest": "^28.1.6",
         "@types/js-yaml": "^4.0.5",
         "@types/mdast": "^3.0.10",
+        "jats-xml": "^0.1.0",
         "jest": "^28.1.3",
         "js-yaml": "^4.1.0",
         "myst-cli-utils": "^0.0.12",
@@ -18946,11 +18960,17 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jats-tags": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jats-tags/-/jats-tags-0.1.0.tgz",
+      "integrity": "sha512-kCL1fqhhWDLTGeA07y1O2xxlh2SN+4UvziF2BUSBEAWNzWSTgio7aaH1lK8WN1ajuMmqz+2/+zSlpVexVZUtwA=="
+    },
     "jats-to-myst": {
       "version": "file:packages/jats-to-myst",
       "requires": {
         "@types/jest": "^28.1.6",
-        "jats-xml": "^0.0.16",
+        "jats-tags": "^0.1.0",
+        "jats-xml": "^0.1.0",
         "jest": "^28.1.3",
         "myst-common": "^0.0.17",
         "myst-frontmatter": "^0.0.13",
@@ -18968,12 +18988,15 @@
       }
     },
     "jats-xml": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-0.0.16.tgz",
-      "integrity": "sha512-dHaoNjrebbYIoVu7jh8mzVCh2jWXgReOJO1MCAcMqzsKcys9svXPHszg8+TsYNlIBkv4R6H6lVUp1WPKtb9P4Q==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jats-xml/-/jats-xml-0.1.0.tgz",
+      "integrity": "sha512-G/VXaUJSAPj29cUjtOK/1j8WaqBMX0Dwo7afMS14lSjfcEbMub2w5OBJ+xGgHVQUA1ucNrKSonJVTCwyApUDtQ==",
       "requires": {
         "fair-principles": "^1.0.3",
+        "jats-tags": "^0.1.0",
+        "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.7",
+        "unist-util-is": "^5.2.1",
         "unist-util-remove": "^3.1.0",
         "unist-util-select": "^4.0.0",
         "unzipper": "^0.10.11",
@@ -20929,7 +20952,8 @@
         "@types/js-yaml": "^4.0.5",
         "@types/mdast": "^3.0.10",
         "citation-js-utils": "^0.0.15",
-        "jats-xml": "^0.0.16",
+        "jats-tags": "^0.1.0",
+        "jats-xml": "^0.1.0",
         "jest": "^28.1.3",
         "js-yaml": "^4.1.0",
         "myst-cli-utils": "^0.0.12",
@@ -23049,7 +23073,12 @@
       "version": "2.0.0"
     },
     "unist-util-is": {
-      "version": "5.1.1"
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
     },
     "unist-util-map": {
       "version": "3.1.1",

--- a/packages/jats-to-myst/package.json
+++ b/packages/jats-to-myst/package.json
@@ -44,7 +44,8 @@
     "url": "https://github.com/executablebooks/mystjs/issues"
   },
   "dependencies": {
-    "jats-xml": "^0.0.16",
+    "jats-tags": "^0.1.0",
+    "jats-xml": "^0.1.0",
     "myst-common": "^0.0.17",
     "myst-frontmatter": "^0.0.13",
     "myst-spec": "^0.0.4",

--- a/packages/jats-to-myst/src/index.ts
+++ b/packages/jats-to-myst/src/index.ts
@@ -8,7 +8,8 @@ import { toText, copyNode, fileError } from 'myst-common';
 import { select, selectAll } from 'unist-util-select';
 import { u } from 'unist-builder';
 import type { Handler, IJatsParser, JatsResult, Options, StateData } from './types';
-import { Jats, RefType } from 'jats-xml';
+import { RefType } from 'jats-tags';
+import { Jats } from 'jats-xml';
 import { keysTransform } from 'myst-transforms';
 import { basicTransformations } from './transforms';
 

--- a/packages/jats-to-myst/src/transforms/admonitions.ts
+++ b/packages/jats-to-myst/src/transforms/admonitions.ts
@@ -4,7 +4,7 @@ import type { GenericParent } from 'myst-common';
 import { fileWarn } from 'myst-common';
 import { select, selectAll } from 'unist-util-select';
 import { remove } from 'unist-util-remove';
-import { Tags } from 'jats-xml';
+import { Tags } from 'jats-tags';
 import type { VFile } from 'vfile';
 
 export type Section = Omit<Heading, 'type'> & { type: 'section' };

--- a/packages/jats-to-myst/src/transforms/typography.ts
+++ b/packages/jats-to-myst/src/transforms/typography.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'unified';
 import type { GenericParent } from 'myst-common';
 import { unnestTransform } from 'myst-transforms';
-import { Tags } from 'jats-xml';
+import { Tags } from 'jats-tags';
 
 export function typographyTransform(tree: GenericParent) {
   unnestTransform(tree, Tags.p, Tags.list);

--- a/packages/myst-to-jats/package.json
+++ b/packages/myst-to-jats/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "citation-js-utils": "^0.0.15",
-    "jats-xml": "^0.0.16",
+    "jats-tags": "^0.1.0",
     "myst-common": "^0.0.17",
     "myst-frontmatter": "^0.0.13",
     "myst-spec": "^0.0.4",
@@ -60,6 +60,7 @@
     "@types/jest": "^28.1.6",
     "@types/js-yaml": "^4.0.5",
     "@types/mdast": "^3.0.10",
+    "jats-xml": "^0.1.0",
     "jest": "^28.1.3",
     "js-yaml": "^4.1.0",
     "myst-cli-utils": "^0.0.12",

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -8,7 +8,7 @@ import type { CitationRenderer } from 'citation-js-utils';
 import type { MessageInfo, GenericNode } from 'myst-common';
 import { SourceFileKind, copyNode, fileError } from 'myst-common';
 import type { PageFrontmatter } from 'myst-frontmatter';
-import { Tags, RefType } from 'jats-xml';
+import { Tags, RefType } from 'jats-tags';
 import type { MinifiedOutput } from 'nbtx';
 import { getBack } from './backmatter';
 import { getArticleMeta, getFront } from './frontmatter';


### PR DESCRIPTION
This fixes some downstream dependencies in using jats in the browser.