### PR TITLE
🔧 Fixes for JATS validation

### DIFF
--- a/packages/myst-cli/src/process/notebook.ts
+++ b/packages/myst-cli/src/process/notebook.ts
@@ -21,7 +21,8 @@ function createOutputDirective(): { myst: string; id: string } {
 }
 
 function blockDivider(cell: ICell, index: number) {
-  const id = cell.metadata.id ?? `nb-cell-${index}`;
+  const id =
+    cell.metadata.id ?? `nb-cell-${index}-${computeHash(JSON.stringify(cell)).substring(0, 10)}`;
   const type = cell.cell_type === CELL_TYPES.code ? NotebookCell.code : NotebookCell.content;
   return `+++ ${JSON.stringify({ id, type, ...cell.metadata })}\n\n`;
 }

--- a/packages/myst-cli/src/transforms/embed.ts
+++ b/packages/myst-cli/src/transforms/embed.ts
@@ -36,8 +36,9 @@ export function embedDirective(
     if (!url) return;
     const source: Dependency = { url };
     if (file) {
-      const { kind } = selectFile(session, file) ?? {};
+      const { kind, slug } = selectFile(session, file) ?? {};
       if (kind) source.kind = kind;
+      if (slug) source.slug = slug;
     }
     node.source = source;
     if (!dependencies.map((dep) => dep.url).includes(url)) dependencies.push(source);

--- a/packages/myst-common/src/types.ts
+++ b/packages/myst-common/src/types.ts
@@ -33,6 +33,7 @@ export enum NotebookCell {
 
 export type Dependency = {
   url: string;
+  slug?: string;
   kind?: SourceFileKind;
 };
 

--- a/packages/myst-to-jats/src/backmatter.ts
+++ b/packages/myst-to-jats/src/backmatter.ts
@@ -1,7 +1,8 @@
 import type { CitationRenderer, CitationJson } from 'citation-js-utils';
-import type { Element } from './types.js';
+import type { Element, IJatsSerializer } from './types.js';
+import { notebookArticleSuffix } from './utils.js';
 
-export function citeToJatsRef(key: string, data: CitationJson): Element {
+export function citeToJatsRef(state: IJatsSerializer, key: string, data: CitationJson): Element {
   const publicationType = !data.type || data.type === 'article-journal' ? 'journal' : data.type;
   const elements: Element[] = [];
   const authors: Element[] | undefined = data.author
@@ -112,7 +113,7 @@ export function citeToJatsRef(key: string, data: CitationJson): Element {
   return {
     type: 'element',
     name: 'ref',
-    attributes: { id: key },
+    attributes: { id: `${key}${notebookArticleSuffix(state)}` },
     elements: [
       {
         type: 'element',
@@ -124,12 +125,12 @@ export function citeToJatsRef(key: string, data: CitationJson): Element {
   };
 }
 
-export function getRefList(citations?: CitationRenderer): Element[] {
+export function getRefList(state: IJatsSerializer, citations?: CitationRenderer): Element[] {
   if (!citations || !Object.keys(citations).length) return [];
   const elements = Object.keys(citations)
     .sort()
     .map((key) => {
-      return citeToJatsRef(key, citations[key].cite);
+      return citeToJatsRef(state, key, citations[key].cite);
     });
   return [{ type: 'element', name: 'ref-list', elements }];
 }
@@ -151,17 +152,20 @@ export function getExpressions(expressions?: Element[]): Element[] {
   ];
 }
 
-export function getBack({
-  citations,
-  footnotes,
-  expressions,
-}: {
-  citations?: CitationRenderer;
-  footnotes?: Element[];
-  expressions?: Element[];
-}): Element[] {
+export function getBack(
+  state: IJatsSerializer,
+  {
+    citations,
+    footnotes,
+    expressions,
+  }: {
+    citations?: CitationRenderer;
+    footnotes?: Element[];
+    expressions?: Element[];
+  },
+): Element[] {
   const elements = [
-    ...getRefList(citations),
+    ...getRefList(state, citations),
     ...getFootnotes(footnotes),
     ...getExpressions(expressions),
     // ack

--- a/packages/myst-to-jats/src/backmatter.ts
+++ b/packages/myst-to-jats/src/backmatter.ts
@@ -1,6 +1,6 @@
 import type { CitationRenderer, CitationJson } from 'citation-js-utils';
 import type { Element, IJatsSerializer } from './types.js';
-import { notebookArticleSuffix } from './utils.js';
+import { notebookArticleSuffix, slugSuffix } from './utils.js';
 
 export function citeToJatsRef(state: IJatsSerializer, key: string, data: CitationJson): Element {
   const publicationType = !data.type || data.type === 'article-journal' ? 'journal' : data.type;
@@ -113,7 +113,7 @@ export function citeToJatsRef(state: IJatsSerializer, key: string, data: Citatio
   return {
     type: 'element',
     name: 'ref',
-    attributes: { id: `${key}${notebookArticleSuffix(state)}` },
+    attributes: { id: `${key}${notebookArticleSuffix(state)}${slugSuffix(state)}` },
     elements: [
       {
         type: 'element',

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -27,7 +27,7 @@ import type { SupplementaryMaterial } from './transforms/containers.js';
 import type { Section } from './transforms/sections.js';
 import { sectionAttrsFromBlock } from './transforms/sections.js';
 import { inlineExpression } from './inlineExpression.js';
-import { notebookArticleSuffix } from './utils.js';
+import { notebookArticleSuffix, slugSuffix } from './utils.js';
 
 type TableCell = SpecTableCell & { colspan?: number; rowspan?: number; width?: number };
 
@@ -355,12 +355,18 @@ const handlers: Record<string, Handler> = {
   },
   cite(node, state) {
     const { label } = node as Cite;
-    const attrs: Attributes = { 'ref-type': 'bibr', rid: label };
+    const attrs: Attributes = {
+      'ref-type': 'bibr',
+      rid: `${label}${notebookArticleSuffix(state)}${slugSuffix(state)}`,
+    };
     state.renderInline(node, 'xref', attrs);
   },
   footnoteReference(node, state) {
     const { identifier, enumerator } = node as FootnoteReference;
-    const attrs: Attributes = { 'ref-type': 'fn', rid: `fn-${identifier}` };
+    const attrs: Attributes = {
+      'ref-type': 'fn',
+      rid: `fn-${identifier}${notebookArticleSuffix(state)}`,
+    };
     state.openNode('xref', attrs);
     state.text(enumerator);
     state.closeNode();
@@ -479,6 +485,7 @@ class JatsSerializer implements IJatsSerializer {
     this.file = file;
     this.data = {
       isNotebookArticleRep: opts?.isNotebookArticleRep,
+      slug: opts?.slug,
     };
     this.stack = [{ type: 'element', elements: [] }];
     this.footnotes = [];

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -136,9 +136,7 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node);
   },
   blockquote(node, state) {
-    state.openNode('p');
     state.renderInline(node, 'disp-quote');
-    state.closeNode();
   },
   definitionList(node, state) {
     state.renderInline(node, 'def-list');

--- a/packages/myst-to-jats/src/index.ts
+++ b/packages/myst-to-jats/src/index.ts
@@ -27,8 +27,13 @@ import type { SupplementaryMaterial } from './transforms/containers.js';
 import type { Section } from './transforms/sections.js';
 import { sectionAttrsFromBlock } from './transforms/sections.js';
 import { inlineExpression } from './inlineExpression.js';
+import { notebookArticleSuffix } from './utils.js';
 
 type TableCell = SpecTableCell & { colspan?: number; rowspan?: number; width?: number };
+
+function escapeForXML(text: string) {
+  return text.replace(/&(?!amp;)/g, '&amp;').replace(/</g, '&lt;');
+}
 
 function referenceKindToRefType(kind?: string): RefType {
   switch (kind) {
@@ -61,7 +66,7 @@ function alternativesFromMinifiedOutput(output: MinifiedOutput, state: IJatsSeri
       'specific-use': 'error',
       mimetype: 'text',
       'mime-subtype': 'plain',
-      'xlink:href': (output as any).path,
+      'xlink:href': escapeForXML((output as any).path),
     });
     state.openNode('caption');
     state.openNode('title');
@@ -77,7 +82,7 @@ function alternativesFromMinifiedOutput(output: MinifiedOutput, state: IJatsSeri
       'specific-use': 'stream',
       mimetype: 'text',
       'mime-subtype': 'plain',
-      'xlink:href': (output as any).path,
+      'xlink:href': escapeForXML((output as any).path),
     });
   } else if (
     ['display_data', 'execute_result', 'update_display_data'].includes(output.output_type)
@@ -102,7 +107,7 @@ function alternativesFromMinifiedOutput(output: MinifiedOutput, state: IJatsSeri
         'specific-use': specificUse,
         mimetype: mimeType.split('/')[0],
         'mime-subtype': mimeType.split('/').slice(1).join('/'),
-        'xlink:href': (value as any).path,
+        'xlink:href': escapeForXML((value as any).path),
       });
     });
   }
@@ -117,7 +122,11 @@ const handlers: Record<string, Handler> = {
     state.renderInline(node, 'p');
   },
   section(node, state) {
-    state.renderInline(node, 'sec', sectionAttrsFromBlock(node as Section));
+    state.renderInline(
+      node,
+      'sec',
+      sectionAttrsFromBlock(node as Section, notebookArticleSuffix(state)),
+    );
   },
   heading(node, state) {
     renderLabel(node, state);
@@ -127,7 +136,9 @@ const handlers: Record<string, Handler> = {
     state.renderChildren(node);
   },
   blockquote(node, state) {
+    state.openNode('p');
     state.renderInline(node, 'disp-quote');
+    state.closeNode();
   },
   definitionList(node, state) {
     state.renderInline(node, 'def-list');
@@ -147,7 +158,7 @@ const handlers: Record<string, Handler> = {
     const { lang, executable, identifier } = node as Code;
     const attrs: Attributes = { language: lang };
     if (executable) attrs.executable = 'yes';
-    if (identifier) attrs.id = identifier;
+    if (identifier) attrs.id = `${identifier}${notebookArticleSuffix(state)}`;
     state.renderInline(node, 'code', attrs);
   },
   list(node, state) {
@@ -178,7 +189,11 @@ const handlers: Record<string, Handler> = {
     state.closeNode();
   },
   math(node, state) {
-    state.openNode('disp-formula', { id: node.identifier });
+    const dispFormulaAttrs: Attributes = {};
+    if (node.identifier) {
+      dispFormulaAttrs.id = `${node.identifier}${notebookArticleSuffix(state)}`;
+    }
+    state.openNode('disp-formula', dispFormulaAttrs);
     renderLabel(node, state, (enumerator) => `(${enumerator})`);
     state.openNode('tex-math');
     state.addLeaf('cdata', { cdata: node.value });
@@ -233,7 +248,10 @@ const handlers: Record<string, Handler> = {
     state.renderInline(node, 'abbrev', { alt: node.title });
   },
   link(node, state) {
-    state.renderInline(node, 'ext-link', { 'ext-link-type': 'uri', 'xlink:href': node.url });
+    state.renderInline(node, 'ext-link', {
+      'ext-link-type': 'uri',
+      'xlink:href': escapeForXML(node.url),
+    });
   },
   admonition(node, state) {
     // This is `boxed-text`, the content-type is used to differentiate it
@@ -284,7 +302,7 @@ const handlers: Record<string, Handler> = {
     const attrs: Record<string, any> = { mimetype: 'image' };
     const ext = node.url ? path.extname(node.url).slice(1) : '';
     if (ext) attrs['mime-subtype'] = ext;
-    attrs['xlink:href'] = node.url;
+    attrs['xlink:href'] = escapeForXML(node.url);
     // TOOD: identifier?
     state.addLeaf('graphic', attrs);
   },
@@ -320,6 +338,7 @@ const handlers: Record<string, Handler> = {
     state.renderInline(node, 'caption');
   },
   captionNumber(node, state) {
+    delete node.identifier;
     state.renderInline(node, 'label');
   },
   crossReference(node, state) {
@@ -348,7 +367,7 @@ const handlers: Record<string, Handler> = {
   },
   footnoteDefinition(node, state) {
     const { identifier, enumerator } = node as FootnoteDefinition;
-    state.openNode('fn', { id: `fn-${identifier}` });
+    state.openNode('fn', { id: `fn-${identifier}${notebookArticleSuffix(state)}` });
     state.openNode('label');
     state.text(enumerator);
     state.closeNode();
@@ -376,7 +395,10 @@ const handlers: Record<string, Handler> = {
     const attrId = identifier ?? id;
     node.data?.forEach((output: any, index: number) => {
       const idSuffix = node.data.length > 1 ? `-${index}` : '';
-      state.openNode('sec', { ...attrs, id: `${attrId}${idSuffix}` });
+      state.openNode('sec', {
+        ...attrs,
+        id: `${attrId}${idSuffix}${notebookArticleSuffix(state)}`,
+      });
       alternativesFromMinifiedOutput(output, state);
       state.closeNode();
     });
@@ -393,7 +415,7 @@ const handlers: Record<string, Handler> = {
     state.openNode('p');
     const smAttrs: Record<string, any> = {};
     if (smNode.figIdentifier) {
-      smAttrs.id = `${smNode.figIdentifier}-source`;
+      smAttrs.id = `${smNode.figIdentifier}-source${notebookArticleSuffix(state)}`;
     }
     smAttrs['specific-use'] = 'notebook';
     state.openNode('supplementary-material', smAttrs);
@@ -410,14 +432,14 @@ const handlers: Record<string, Handler> = {
     }
     state.text('.');
     state.closeNode();
+    state.openNode('p');
     state.text('See methods');
-    if (smNode.sourceUrl) {
-      const sourceIdentifier = smNode.sourceUrl.split('/')[smNode.sourceUrl.split('/').length - 1];
+    if (smNode.sourceSlug) {
       state.text(' in ');
       state.openNode('xref', {
         'ref-type': 'custom',
         'custom-type': 'notebook',
-        rid: sourceIdentifier,
+        rid: smNode.sourceSlug,
       });
       state.text('notebook');
       state.closeNode();
@@ -436,12 +458,13 @@ const handlers: Record<string, Handler> = {
     state.closeNode();
     state.closeNode();
     state.closeNode();
+    state.closeNode();
   },
   inlineExpression,
 };
 
 function createText(text: string): Element {
-  return { type: 'text', text };
+  return { type: 'text', text: escapeForXML(text) };
 }
 
 class JatsSerializer implements IJatsSerializer {
@@ -454,7 +477,9 @@ class JatsSerializer implements IJatsSerializer {
 
   constructor(file: VFile, mdast: Root, opts?: Options) {
     this.file = file;
-    this.data = {};
+    this.data = {
+      isNotebookArticleRep: opts?.isNotebookArticleRep,
+    };
     this.stack = [{ type: 'element', elements: [] }];
     this.footnotes = [];
     this.expressions = [];
@@ -498,7 +523,7 @@ class JatsSerializer implements IJatsSerializer {
     const last = top.elements?.[top.elements.length - 1];
     if (last?.type === 'text') {
       // The last node is also text, merge it
-      last.text += `${value}`;
+      last.text += `${escapeForXML(value)}`;
       return last;
     }
     const node = createText(value);
@@ -522,7 +547,10 @@ class JatsSerializer implements IJatsSerializer {
 
   renderInline(node: GenericNode, name: string, attributes?: Attributes) {
     this.openNode(name, {
-      id: name !== 'xref' && node.identifier ? node.identifier : undefined,
+      id:
+        name !== 'xref' && node.identifier
+          ? `${node.identifier}${notebookArticleSuffix(this)}`
+          : undefined,
       ...attributes,
     });
     if ('children' in node) {
@@ -579,22 +607,28 @@ export class JatsDocument {
     };
     if (articleType) attributes['article-type'] = articleType;
     if (specificUse) attributes['specific-use'] = specificUse;
-    if (this.content.slug) attributes.id = this.content.slug;
-    const state = new JatsSerializer(this.file, this.content.mdast, this.options);
+    const isNotebookArticleRep = this.content.kind === SourceFileKind.Notebook;
+    if (this.content.slug) {
+      attributes.id = `${this.content.slug}${isNotebookArticleRep ? '-article' : ''}`;
+    }
+    const state = new JatsSerializer(this.file, this.content.mdast, {
+      ...this.options,
+      isNotebookArticleRep,
+    });
     const subArticles = this.options.subArticles ?? [];
-    if (this.content.kind === SourceFileKind.Notebook) {
+    if (isNotebookArticleRep) {
       subArticles.unshift(this.content);
     }
     const elements: Element[] = [
       ...getFront(this.content.frontmatter),
       this.body(state),
-      ...getBack({
+      ...getBack(state, {
         citations: this.content.citations,
         footnotes: state.footnotes,
         expressions: state.expressions,
       }),
       ...subArticles.map((article, ind) =>
-        this.subArticle(article, ind === 0 && this.content.kind === SourceFileKind.Notebook),
+        this.subArticle(article, ind === 0 && isNotebookArticleRep),
       ),
     ];
     const article: Element = {
@@ -632,12 +666,14 @@ export class JatsDocument {
   subArticle(content: ArticleContent, notebookRep: boolean): Element {
     const state = new JatsSerializer(this.file, content.mdast, {
       ...this.options,
+      isNotebookArticleRep: false,
       isSubArticle: true,
+      slug: content.slug,
     });
     const elements: Element[] = [
       ...this.frontStub(content.frontmatter, notebookRep),
       { type: 'element', name: 'body', elements: state.elements() },
-      ...getBack({
+      ...getBack(state, {
         citations: content.citations,
         footnotes: state.footnotes,
         expressions: state.expressions,

--- a/packages/myst-to-jats/src/inlineExpression.ts
+++ b/packages/myst-to-jats/src/inlineExpression.ts
@@ -1,5 +1,6 @@
 import type { InlineExpression } from 'myst-spec-ext';
 import type { Element, Handler } from './types.js';
+import { notebookArticleSuffix } from './utils.js';
 
 // function renderMimeToJats(state: IJatsSerializer, node: GenericNode): Element[] {
 //   const { result } = node as InlineExpression;
@@ -24,7 +25,7 @@ export const inlineExpression: Handler = (node, state) => {
   const element = {
     type: 'element',
     name: 'sec',
-    attributes: { id: identifier, 'sec-type': 'expression' },
+    attributes: { id: `${identifier}${notebookArticleSuffix(state)}`, 'sec-type': 'expression' },
     elements: [
       {
         type: 'element',

--- a/packages/myst-to-jats/src/transforms/containers.ts
+++ b/packages/myst-to-jats/src/transforms/containers.ts
@@ -9,6 +9,7 @@ export type SupplementaryMaterial = {
   enumerator?: string;
   figIdentifier?: string;
   sourceUrl?: string;
+  sourceSlug?: string;
   embedIdentifier?: string;
 };
 
@@ -42,6 +43,12 @@ export function containerTransform(mdast: Root) {
       caption.children.push(...legendChildren);
       remove(container as any, 'legend');
     }
+    if ((container as any).kind === 'figure') {
+      container.children = [
+        ...container.children.filter((child) => child.type !== 'image'),
+        ...container.children.filter((child) => child.type === 'image'),
+      ];
+    }
     const embed = select('embed', container);
     if (embed) {
       const embedBlock = select('block', embed);
@@ -51,6 +58,7 @@ export function containerTransform(mdast: Root) {
         enumerator: container.enumerator,
         figIdentifier: container.identifier,
         sourceUrl: (embed as any).source?.url,
+        sourceSlug: (embed as any).source?.slug,
         embedIdentifier: (embedBlock as any)?.identifier,
       } as SupplementaryMaterial);
       if (embedOutputs) container.children.push(...(embedOutputs as any[]));

--- a/packages/myst-to-jats/src/transforms/sections.ts
+++ b/packages/myst-to-jats/src/transforms/sections.ts
@@ -70,11 +70,10 @@ function headingsToSections(tree: Root | Block, current?: Section) {
 /**
  * This transform does the following:
  * - For sub-articles:
- *    - Blocks are converted directly to sections with no additional transformation.
- *    - This means notebook cell divisions are maintained.
- *    - However, markdown sub-articles do not get divided into sections by header.
+ *    - Blocks are converted to sections so notebook cell divisions are maintained.
+ *    - Within each block, headers are converted to sections.
  * - For main articles:
- *    - Notebook code cell blocks (with meta.type of "notebook-code") are removed.
+ *    - Notebook code cell blocks (with meta.type of "notebook-code") are deleted.
  *    - Remaining blocks are removed, lifting children up a level
  *    - Top-level heading nodes are then used to break the tree into section nodes,
  *      with heading and subsequent nodes as children

--- a/packages/myst-to-jats/src/transforms/sections.ts
+++ b/packages/myst-to-jats/src/transforms/sections.ts
@@ -8,7 +8,10 @@ import type { Options } from '../types.js';
 
 export type Section = Omit<Heading, 'type'> & { type: 'section'; meta?: string };
 
-export function sectionAttrsFromBlock(node: { data?: Record<string, any>; identifier?: string }) {
+export function sectionAttrsFromBlock(
+  node: { data?: Record<string, any>; identifier?: string },
+  idSuffix?: string,
+) {
   const output: { 'sec-type'?: string; id?: string } = {};
   if (node.data) {
     const blockType = node.data.type;
@@ -16,7 +19,7 @@ export function sectionAttrsFromBlock(node: { data?: Record<string, any>; identi
       output['sec-type'] = blockType;
     }
   }
-  if (node.identifier) output.id = node.identifier;
+  if (node.identifier) output.id = `${node.identifier}${idSuffix ?? ''}`;
   return output;
 }
 
@@ -27,6 +30,41 @@ function blockIsNotebookCode(node: Block) {
 
 function blockIsNotebookFigure(node: Block) {
   return !!node.data?.['fig-cap'];
+}
+
+function headingsToSections(tree: Root | Block, current?: Section) {
+  const children: Parent[] = [];
+  // let current: Section | undefined = undefined;
+  function push(child: any) {
+    if (current) {
+      current.children.push(child);
+    } else {
+      children.push(child);
+    }
+  }
+
+  function newSection(heading: Heading) {
+    const { enumerator, enumerated, ...filtered } = heading;
+    if (current && current.depth < heading.depth) {
+      // Nest the section
+      const next: Section = { ...filtered, type: 'section', children: [] };
+      push(next);
+      current = next;
+      return { enumerator, enumerated };
+    }
+    current = { ...filtered, type: 'section', children: [] };
+    children.push(current);
+    return { enumerator, enumerated };
+  }
+  tree.children?.forEach((child) => {
+    if (child.type === 'heading') {
+      const { enumerator, enumerated } = newSection(child as Heading);
+      push({ type: 'heading', enumerator, enumerated, children: child.children });
+    } else {
+      push(child);
+    }
+  });
+  tree.children = children as any;
 }
 
 /**
@@ -45,6 +83,8 @@ export function sectionTransform(tree: Root, opts: Options) {
   if (opts.isSubArticle) {
     (selectAll('block', tree) as Block[]).forEach((node) => {
       (node as any).type = 'section';
+      (node as any).depth = 0;
+      headingsToSections(node);
     });
     return;
   }
@@ -61,37 +101,7 @@ export function sectionTransform(tree: Root, opts: Options) {
     tree.children = [];
   }
   liftChildren(tree, 'block'); // this looses part information. TODO: milestones
-  const children: Parent[] = [];
-  let current: Section | undefined = undefined;
-  function push(child: any) {
-    if (current) {
-      current.children.push(child);
-    } else {
-      children.push(child);
-    }
-  }
-  function newSection(heading: Heading) {
-    const { enumerator, enumerated, ...filtered } = heading;
-    if (current && current.depth < heading.depth) {
-      // Nest the section
-      const next: Section = { ...filtered, type: 'section', children: [] };
-      push(next);
-      current = next;
-      return { enumerator, enumerated };
-    }
-    current = { ...filtered, type: 'section', children: [] };
-    children.push(current);
-    return { enumerator, enumerated };
-  }
-  tree.children.forEach((child) => {
-    if (child.type === 'heading') {
-      const { enumerator, enumerated } = newSection(child as Heading);
-      push({ type: 'heading', enumerator, enumerated, children: child.children });
-    } else {
-      push(child);
-    }
-  });
-  tree.children = children as any;
+  headingsToSections(tree);
 }
 
 export const sectionPlugin: Plugin<[Options], Root, Root> = (opts) => (tree) => {

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -20,7 +20,9 @@ export type MathPlugins = Required<PageFrontmatter>['math'];
 
 export type Options = {
   handlers?: Record<string, Handler>;
+  isNotebookArticleRep?: boolean;
   isSubArticle?: boolean;
+  slug?: string;
 };
 
 export type DocumentOptions = Options & {
@@ -31,6 +33,7 @@ export type DocumentOptions = Options & {
 
 export type StateData = {
   isInContainer?: boolean;
+  isNotebookArticleRep?: boolean;
 };
 
 export type ArticleContent = {

--- a/packages/myst-to-jats/src/types.ts
+++ b/packages/myst-to-jats/src/types.ts
@@ -34,6 +34,7 @@ export type DocumentOptions = Options & {
 export type StateData = {
   isInContainer?: boolean;
   isNotebookArticleRep?: boolean;
+  slug?: string;
 };
 
 export type ArticleContent = {

--- a/packages/myst-to-jats/src/utils.ts
+++ b/packages/myst-to-jats/src/utils.ts
@@ -1,7 +1,7 @@
 import type { IJatsSerializer } from './types.js';
 
 export function notebookArticleSuffix(state: IJatsSerializer) {
-  return state.data.isNotebookArticleRep ? '-article' : '';
+  return state.data.isNotebookArticleRep ? '-jats-article' : '';
 }
 
 export function slugSuffix(state: IJatsSerializer) {

--- a/packages/myst-to-jats/src/utils.ts
+++ b/packages/myst-to-jats/src/utils.ts
@@ -1,0 +1,5 @@
+import type { IJatsSerializer } from './types';
+
+export function notebookArticleSuffix(state: IJatsSerializer) {
+  return state.data.isNotebookArticleRep ? '-article' : '';
+}

--- a/packages/myst-to-jats/src/utils.ts
+++ b/packages/myst-to-jats/src/utils.ts
@@ -1,5 +1,9 @@
-import type { IJatsSerializer } from './types';
+import type { IJatsSerializer } from './types.js';
 
 export function notebookArticleSuffix(state: IJatsSerializer) {
   return state.data.isNotebookArticleRep ? '-article' : '';
+}
+
+export function slugSuffix(state: IJatsSerializer) {
+  return state.data.slug ? `-${state.data.slug}` : '';
 }

--- a/packages/myst-to-jats/tests/basic.yml
+++ b/packages/myst-to-jats/tests/basic.yml
@@ -275,7 +275,7 @@ cases:
               children:
                 - type: text
                   value: We know what we are, but know not what we may be.
-    jats: <p><disp-quote><p>We know what we are, but know not what we may be.</p></disp-quote></p>
+    jats: <disp-quote><p>We know what we are, but know not what we may be.</p></disp-quote>
   - title: Blockquote with attribution
     tree:
       type: root
@@ -295,7 +295,7 @@ cases:
                   children:
                     - type: text
                       value: Hamlet act 4, Scene 5
-    jats: <p><disp-quote><p>We know what we are, but know not what we may be.</p><attrib>Hamlet act 4, Scene 5</attrib></disp-quote></p>
+    jats: <disp-quote><p>We know what we are, but know not what we may be.</p><attrib>Hamlet act 4, Scene 5</attrib></disp-quote>
   - title: Definition List
     tree:
       type: root

--- a/packages/myst-to-jats/tests/basic.yml
+++ b/packages/myst-to-jats/tests/basic.yml
@@ -275,7 +275,7 @@ cases:
               children:
                 - type: text
                   value: We know what we are, but know not what we may be.
-    jats: <disp-quote><p>We know what we are, but know not what we may be.</p></disp-quote>
+    jats: <p><disp-quote><p>We know what we are, but know not what we may be.</p></disp-quote></p>
   - title: Blockquote with attribution
     tree:
       type: root
@@ -295,7 +295,7 @@ cases:
                   children:
                     - type: text
                       value: Hamlet act 4, Scene 5
-    jats: <disp-quote><p>We know what we are, but know not what we may be.</p><attrib>Hamlet act 4, Scene 5</attrib></disp-quote>
+    jats: <p><disp-quote><p>We know what we are, but know not what we may be.</p><attrib>Hamlet act 4, Scene 5</attrib></disp-quote></p>
   - title: Definition List
     tree:
       type: root
@@ -422,7 +422,7 @@ cases:
                   children:
                     - type: text
                       value: Relaxing at the beach
-    jats: <fig id="myfigure"><alt-text>Random image of the beach or ocean!</alt-text><graphic mimetype="image" mime-subtype="png" xlink:href="beach.png"/><caption><p>Relaxing at the beach</p></caption></fig>
+    jats: <fig id="myfigure"><caption><p>Relaxing at the beach</p></caption><alt-text>Random image of the beach or ocean!</alt-text><graphic mimetype="image" mime-subtype="png" xlink:href="beach.png"/></fig>
   - title: Figure (captionNumber)
     tree:
       type: root
@@ -444,7 +444,7 @@ cases:
                       value: 'Figure 1:'
                     - type: text
                       value: Relaxing at the beach
-    jats: <fig id="myfigure"><label>Figure 1:</label><alt-text>Random image of the beach or ocean!</alt-text><graphic mimetype="image" mime-subtype="png" xlink:href="beach.png"/><caption><p>Relaxing at the beach</p></caption></fig>
+    jats: <fig id="myfigure"><label>Figure 1:</label><caption><p>Relaxing at the beach</p></caption><alt-text>Random image of the beach or ocean!</alt-text><graphic mimetype="image" mime-subtype="png" xlink:href="beach.png"/></fig>
   - title: Table Container
     tree:
       type: root
@@ -631,7 +631,7 @@ cases:
                   children:
                     - type: text
                       value: Another Legend
-    jats: <fig id="myfigure"><alt-text>Random image of the beach or ocean!</alt-text><graphic mimetype="image" mime-subtype="png" xlink:href="beach.png"/><caption><p>My Caption</p><p>My Legend</p><p>Another Legend</p></caption></fig>
+    jats: <fig id="myfigure"><caption><p>My Caption</p><p>My Legend</p><p>Another Legend</p></caption><alt-text>Random image of the beach or ocean!</alt-text><graphic mimetype="image" mime-subtype="png" xlink:href="beach.png"/></fig>
   - title: Figure with embeded output
     tree:
       type: root
@@ -701,4 +701,4 @@ cases:
                   children:
                     - type: text
                       value: My Legend
-    jats: <fig id="myfigure"><caption><p>My Caption</p><p>My Legend</p><p><supplementary-material id="myfigure-source" specific-use="notebook"><label>Figure 1 - Notebook.</label><caption><title>Analysis for <xref ref-type="fig" rid="myfigure">Figure 1</xref>.</title>See methods in <xref ref-type="custom" custom-type="notebook" rid="nb-0">notebook</xref> from <xref ref-type="custom" custom-type="notebook-code" rid="nb-cell-0">cell</xref>.</caption></supplementary-material></p></caption><alternatives><media specific-use="stream" mimetype="text" mime-subtype="plain" xlink:href="files/a.txt"/></alternatives><alternatives><media specific-use="text" mimetype="text" mime-subtype="plain" xlink:href="files/b.txt"/><media specific-use="web" mimetype="text" mime-subtype="html" xlink:href="files/b.html"/></alternatives></fig>
+    jats: <fig id="myfigure"><caption><p>My Caption</p><p>My Legend</p><p><supplementary-material id="myfigure-source" specific-use="notebook"><label>Figure 1 - Notebook.</label><caption><title>Analysis for <xref ref-type="fig" rid="myfigure">Figure 1</xref>.</title><p>See methods from <xref ref-type="custom" custom-type="notebook-code" rid="nb-cell-0">cell</xref>.</p></caption></supplementary-material></p></caption><alternatives><media specific-use="stream" mimetype="text" mime-subtype="plain" xlink:href="files/a.txt"/></alternatives><alternatives><media specific-use="text" mimetype="text" mime-subtype="plain" xlink:href="files/b.txt"/><media specific-use="web" mimetype="text" mime-subtype="html" xlink:href="files/b.html"/></alternatives></fig>

--- a/packages/myst-to-jats/tests/notebooks.yml
+++ b/packages/myst-to-jats/tests/notebooks.yml
@@ -196,7 +196,7 @@ cases:
           <article-meta/>
         </front>
         <body>
-          <sec id="sec1">
+          <sec id="sec1-article">
             <title>a section</title>
             <p>content</p>
           </sec>
@@ -219,10 +219,14 @@ cases:
               </sec>
             </sec>
             <sec id="nb-cell-1" sec-type="notebook-content">
-              <title id="sec1">a section</title>
-              <p>content</p>
-              <title>Another section</title>
-              <p>section content!</p>
+              <sec id="sec1">
+                <title>a section</title>
+                <p>content</p>
+              </sec>
+              <sec>
+                <title>Another section</title>
+                <p>section content!</p>
+              </sec>
             </sec>
           </body>
         </sub-article>
@@ -265,9 +269,9 @@ cases:
           <article-meta/>
         </front>
         <body>
-          <sec id="nb-cell-0" sec-type="notebook-code">
-            <code id="nb-cell-0-code" language="python" executable="yes">print('abc')</code>
-            <sec sec-type="notebook-output" id="nb-cell-0-output">
+          <sec id="nb-cell-0-article" sec-type="notebook-code">
+            <code id="nb-cell-0-code-article" language="python" executable="yes">print('abc')</code>
+            <sec sec-type="notebook-output" id="nb-cell-0-output-article">
               <alternatives>
                 <media specific-use="stream" mimetype="text" mime-subtype="plain" xlink:href="files/a.txt"/>
               </alternatives>

--- a/packages/myst-to-jats/tests/notebooks.yml
+++ b/packages/myst-to-jats/tests/notebooks.yml
@@ -196,7 +196,7 @@ cases:
           <article-meta/>
         </front>
         <body>
-          <sec id="sec1-article">
+          <sec id="sec1-jats-article">
             <title>a section</title>
             <p>content</p>
           </sec>
@@ -269,9 +269,9 @@ cases:
           <article-meta/>
         </front>
         <body>
-          <sec id="nb-cell-0-article" sec-type="notebook-code">
-            <code id="nb-cell-0-code-article" language="python" executable="yes">print('abc')</code>
-            <sec sec-type="notebook-output" id="nb-cell-0-output-article">
+          <sec id="nb-cell-0-jats-article" sec-type="notebook-code">
+            <code id="nb-cell-0-code-jats-article" language="python" executable="yes">print('abc')</code>
+            <sec sec-type="notebook-output" id="nb-cell-0-output-jats-article">
               <alternatives>
                 <media specific-use="stream" mimetype="text" mime-subtype="plain" xlink:href="files/a.txt"/>
               </alternatives>


### PR DESCRIPTION
This PR makes a bunch of not-super-nice changes to identifiers before and during JATS export so there are no duplicates in the JATS xml. It also fixes a few picky structural aspects of how the xml was constructed.