### PR TITLE
🤖 Meca frontmatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12010,7 +12010,8 @@
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.5",
         "which": "^3.0.1",
-        "ws": "^8.9.0"
+        "ws": "^8.9.0",
+        "xml-js": "^1.6.11"
       },
       "bin": {
         "myst": "dist/myst.cjs"

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -100,7 +100,8 @@
     "unist-util-select": "^4.0.3",
     "vfile": "^5.3.5",
     "which": "^3.0.1",
-    "ws": "^8.9.0"
+    "ws": "^8.9.0",
+    "xml-js": "^1.6.11"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.0",

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -16,6 +16,7 @@ export type BuildOpts = {
   pdf?: boolean;
   tex?: boolean;
   xml?: boolean;
+  meca?: boolean;
   html?: boolean;
   all?: boolean;
   force?: boolean;
@@ -24,12 +25,12 @@ export type BuildOpts = {
 };
 
 export function hasAnyExplicitExportFormat(opts: BuildOpts): boolean {
-  const { docx, pdf, tex, xml } = opts;
-  return docx || pdf || tex || xml || false;
+  const { docx, pdf, tex, xml, meca } = opts;
+  return docx || pdf || tex || xml || meca || false;
 }
 
 export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extension?: string }) {
-  const { docx, pdf, tex, xml, all, explicit, extension } = opts;
+  const { docx, pdf, tex, xml, meca, all, explicit, extension } = opts;
   const formats = [];
   const any = hasAnyExplicitExportFormat(opts);
   const override = all || (!any && explicit && !extension);
@@ -37,13 +38,14 @@ export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extensi
   if (pdf || override || extension === '.pdf') formats.push(ExportFormats.pdf);
   if (tex || override || extension === '.tex') formats.push(ExportFormats.tex);
   if (xml || override || extension === '.xml') formats.push(ExportFormats.xml);
+  if (meca || override) formats.push(ExportFormats.meca);
   return formats;
 }
 
 export function exportSite(session: ISession, opts: BuildOpts) {
-  const { docx, pdf, tex, xml, force, site, html, all } = opts;
+  const { docx, pdf, tex, xml, meca, force, site, html, all } = opts;
   const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
-  return site || html || all || (siteConfig && !force && !docx && !pdf && !tex && !xml);
+  return site || html || all || (siteConfig && !force && !docx && !pdf && !tex && !xml && !meca);
 }
 
 export function getProjectPaths(session: ISession) {

--- a/packages/myst-cli/src/build/clean.ts
+++ b/packages/myst-cli/src/build/clean.ts
@@ -12,6 +12,7 @@ export type CleanOptions = {
   pdf?: boolean;
   tex?: boolean;
   xml?: boolean;
+  meca?: boolean;
   site?: boolean;
   html?: boolean;
   temp?: boolean;
@@ -26,6 +27,7 @@ const ALL_OPTS: CleanOptions = {
   pdf: true,
   tex: true,
   xml: true,
+  meca: true,
   site: true,
   html: true,
   temp: true,
@@ -37,6 +39,7 @@ const DEFAULT_OPTS: CleanOptions = {
   pdf: true,
   tex: true,
   xml: true,
+  meca: true,
   site: true,
   html: true,
   temp: true,
@@ -44,9 +47,9 @@ const DEFAULT_OPTS: CleanOptions = {
 };
 
 function coerceOpts(opts: CleanOptions) {
-  const { docx, pdf, tex, xml, site, html, temp, exports, templates, all } = opts;
+  const { docx, pdf, tex, xml, meca, site, html, temp, exports, templates, all } = opts;
   if (all) return { ...opts, ...ALL_OPTS };
-  if (!docx && !pdf && !tex && !xml && !site && !html && !temp && !exports && !templates) {
+  if (!docx && !pdf && !tex && !xml && !meca && !site && !html && !temp && !exports && !templates) {
     return { ...opts, ...DEFAULT_OPTS };
   }
   return { ...opts };

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -1,0 +1,142 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { hashAndCopyStaticFile, tic } from 'myst-cli-utils';
+import { ExportFormats } from 'myst-frontmatter';
+import type { LinkTransformer } from 'myst-transforms';
+import { js2xml } from 'xml-js';
+import { findCurrentProjectAndLoad } from '../../config.js';
+import { loadProjectFromDisk } from '../../project/index.js';
+import type { ISession } from '../../session/types.js';
+import { createTempFolder, isDirectory } from '../../utils/index.js';
+import type { ExportWithOutput, ExportOptions } from '../types.js';
+import { cleanOutput, collectJatsExportOptions, resolveAndLogErrors } from '../utils/index.js';
+import { runJatsExport } from '../jats/single.js';
+import AdmZip from 'adm-zip';
+import { selectors } from '../../store/index.js';
+
+function copyFilesFromConfig(
+  session: ISession,
+  projectPath: string,
+  folder: string,
+  category: 'resources' | 'requirements',
+) {
+  const projConfig = selectors.selectLocalProjectConfig(session.store.getState(), projectPath);
+  const entries = projConfig[category];
+  if (entries) {
+    const categoryFolder = path.join(folder, category);
+    const filesToCopy: string[] = [];
+    entries.forEach((entry: string) => {
+      let entryParts = entry.split('/');
+      if (entryParts[entryParts.length] === '*') {
+        entryParts = entryParts.slice(0, entryParts.length - 1);
+      }
+      const resolvedEntry = path.join(projectPath, ...entryParts);
+      if (isDirectory(resolvedEntry)) {
+        fs.readdirSync(resolvedEntry).forEach((file) => {
+          const resolvedSubEntry = path.join(resolvedEntry, file);
+          if (!isDirectory(resolvedSubEntry)) filesToCopy.push(resolvedSubEntry);
+        });
+      } else if (fs.existsSync(resolvedEntry)) {
+        filesToCopy.push(resolvedEntry);
+      }
+    });
+    if (filesToCopy.length) {
+      fs.mkdirSync(categoryFolder);
+      filesToCopy.forEach((file: string) => {
+        hashAndCopyStaticFile(session, file, categoryFolder);
+      });
+    }
+  }
+}
+
+function writeMecaManifest(mecaFolder: string) {
+  const folders = ['files', 'requirements', 'resources'];
+  const files: string[] = [];
+  folders.forEach((folder) => {
+    const fullFolder = path.join(mecaFolder, folder);
+    if (fs.existsSync(fullFolder)) {
+      files.push(...fs.readdirSync(fullFolder).map((file) => `${folder}/${file}`));
+    }
+  });
+  const element = {
+    type: 'element',
+    elements: [
+      {
+        type: 'doctype',
+        doctype: 'manifest SYSTEM "manifest.dtd"',
+      },
+      {
+        type: 'element',
+        name: 'manifest',
+        attributes: { version: '1', xmlns: '' },
+        elements: ['Article.xml', ...files].map((file) => {
+          return {
+            type: 'element',
+            name: 'item',
+            elements: [{ type: 'element', name: 'instance', attributes: { href: file } }],
+          };
+        }),
+      },
+    ],
+    declaration: { attributes: { version: '1.0', encoding: 'UTF-8' } },
+  };
+  const jats = js2xml(element, {
+    compact: false,
+    spaces: 2,
+  });
+  fs.writeFileSync(path.join(mecaFolder, 'Manifest.xml'), jats);
+}
+
+export async function runMecaExport(
+  session: ISession,
+  exportOptions: ExportWithOutput,
+  projectPath?: string,
+  clean?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+) {
+  const toc = tic();
+  const { output } = exportOptions;
+  if (clean) cleanOutput(session, output);
+  const mecaFolder = createTempFolder(session);
+  const jatsOutput = path.join(mecaFolder, 'Article.xml');
+  await runJatsExport(
+    session,
+    { ...exportOptions, output: jatsOutput },
+    projectPath,
+    clean,
+    extraLinkTransformers,
+  );
+  if (projectPath) {
+    copyFilesFromConfig(session, projectPath, mecaFolder, 'requirements');
+    copyFilesFromConfig(session, projectPath, mecaFolder, 'resources');
+  }
+  writeMecaManifest(mecaFolder);
+  const zip = new AdmZip();
+  zip.addLocalFolder(mecaFolder);
+  zip.writeZip(output);
+  session.log.info(toc(`🤐 MECA output copied and zipped to ${output} in %s`));
+}
+
+export async function localProjectToMeca(
+  session: ISession,
+  file: string,
+  opts: ExportOptions,
+  templateOptions?: Record<string, any>,
+  extraLinkTransformers?: LinkTransformer[],
+) {
+  let { projectPath } = opts;
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (projectPath) await loadProjectFromDisk(session, projectPath);
+  const exportOptionsList = (
+    await collectJatsExportOptions(session, file, 'zip', [ExportFormats.meca], projectPath, opts)
+  ).map((exportOptions) => {
+    return { ...exportOptions, ...templateOptions };
+  });
+  await resolveAndLogErrors(
+    session,
+    exportOptionsList.map(async (exportOptions) => {
+      await runMecaExport(session, exportOptions, projectPath, opts.clean, extraLinkTransformers);
+    }),
+    opts.throwOnFailure,
+  );
+}

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -63,13 +63,17 @@ function writeMecaManifest(mecaFolder: string) {
     elements: [
       {
         type: 'doctype',
-        doctype: 'manifest SYSTEM "manifest.dtd"',
+        doctype: 'manifest PUBLIC "-//MECA//DTD Manifest v1.0//en" "MECA_manifest.dtd"',
       },
       {
         type: 'element',
         name: 'manifest',
-        attributes: { version: '1', xmlns: '' },
-        elements: ['Article.xml', ...files].map((file) => {
+        attributes: {
+          version: '1',
+          xmlns: 'https://manuscriptexchange.org/schema/manifest',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+        },
+        elements: ['article.xml', ...files].map((file) => {
           return {
             type: 'element',
             name: 'item',
@@ -84,7 +88,7 @@ function writeMecaManifest(mecaFolder: string) {
     compact: false,
     spaces: 2,
   });
-  fs.writeFileSync(path.join(mecaFolder, 'Manifest.xml'), jats);
+  fs.writeFileSync(path.join(mecaFolder, 'manifest.xml'), jats);
 }
 
 export async function runMecaExport(
@@ -98,7 +102,7 @@ export async function runMecaExport(
   const { output } = exportOptions;
   if (clean) cleanOutput(session, output);
   const mecaFolder = createTempFolder(session);
-  const jatsOutput = path.join(mecaFolder, 'Article.xml');
+  const jatsOutput = path.join(mecaFolder, 'article.xml');
   await runJatsExport(
     session,
     { ...exportOptions, output: jatsOutput },

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -304,6 +304,18 @@ export async function collectExportOptions(
           )),
         );
       }
+      if (formats.includes(ExportFormats.meca)) {
+        fileExportOptionsList.push(
+          ...(await collectJatsExportOptions(
+            session,
+            file,
+            'zip',
+            [ExportFormats.meca],
+            fileProjectPath,
+            opts,
+          )),
+        );
+      }
       exportOptionsList.push(
         ...fileExportOptionsList.map((exportOptions) => {
           return { ...exportOptions, $file: file, $project: fileProjectPath };

--- a/packages/myst-cli/src/build/utils/localArticleExport.ts
+++ b/packages/myst-cli/src/build/utils/localArticleExport.ts
@@ -10,6 +10,7 @@ import { runWordExport } from '../docx/single.js';
 import { runJatsExport } from '../jats/single.js';
 import { texExportOptionsFromPdf } from '../pdf/single.js';
 import { createPdfGivenTexExport } from '../pdf/create.js';
+import { runMecaExport } from '../meca/index.js';
 
 export async function localArticleExport(
   session: ISession,
@@ -40,6 +41,8 @@ export async function localArticleExport(
         await runWordExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
       } else if (format === ExportFormats.xml) {
         await runJatsExport(sessionClone, exportOptions, fileProjectPath, clean);
+      } else if (format === ExportFormats.meca) {
+        await runMecaExport(sessionClone, exportOptions, fileProjectPath, clean);
       } else {
         const keepTexAndLogs = format === ExportFormats.pdftex;
         const texExportOptions = texExportOptionsFromPdf(

--- a/packages/myst-cli/src/cli/build.ts
+++ b/packages/myst-cli/src/cli/build.ts
@@ -14,6 +14,7 @@ import {
   makeAllOption,
   makeNamedExportOption,
   makeHtmlOption,
+  makeMecaOptions,
 } from './options.js';
 
 export function makeBuildCLI(program: Command) {
@@ -24,6 +25,7 @@ export function makeBuildCLI(program: Command) {
     .addOption(makeTexOption('Build LaTeX outputs'))
     .addOption(makeDocxOption('Build Docx output'))
     .addOption(makeJatsOption('Build JATS xml output'))
+    .addOption(makeMecaOptions('Build MECA zip output'))
     .addOption(makeSiteOption('Build MyST site content'))
     .addOption(makeHtmlOption('Build static HTML site content'))
     .addOption(makeAllOption('Build all exports'))

--- a/packages/myst-cli/src/cli/clean.ts
+++ b/packages/myst-cli/src/cli/clean.ts
@@ -7,6 +7,7 @@ import {
   makeDocxOption,
   makeHtmlOption,
   makeJatsOption,
+  makeMecaOptions,
   makePdfOption,
   makeSiteOption,
   makeTexOption,
@@ -41,7 +42,8 @@ export function makeCleanCLI(program: Command) {
     .addOption(makePdfOption('Clean PDF output'))
     .addOption(makeTexOption('Clean LaTeX outputs'))
     .addOption(makeDocxOption('Clean Docx output'))
-    .addOption(makeJatsOption('Build JATS xml output'))
+    .addOption(makeJatsOption('Clean JATS xml output'))
+    .addOption(makeMecaOptions('Clean MECA zip output'))
     .addOption(makeSiteOption('Clean MyST site content'))
     .addOption(makeHtmlOption('Clean static HTML site content'))
     .addOption(makeTempOption())

--- a/packages/myst-cli/src/cli/options.ts
+++ b/packages/myst-cli/src/cli/options.ts
@@ -16,6 +16,10 @@ export function makeJatsOption(description: string) {
   return new Option('--jats, --xml', description).default(false);
 }
 
+export function makeMecaOptions(description: string) {
+  return new Option('--meca', description).default(false);
+}
+
 export function makeSiteOption(description: string) {
   return new Option('--site', description).default(false);
 }

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -147,6 +147,8 @@ const TEST_PROJECT_FRONTMATTER: ProjectFrontmatter = {
       sub_articles: ['my-notebook.ipynb'],
     },
   ],
+  requirements: ['requirements.txt'],
+  resources: ['my-script.sh'],
 };
 const TEST_PAGE_FRONTMATTER: PageFrontmatter = {
   title: 'frontmatter',
@@ -444,6 +446,8 @@ describe('fillPageFrontmatter', () => {
     delete result.name;
     delete result.oxa;
     delete result.exports;
+    delete result.requirements;
+    delete result.resources;
     expect(fillPageFrontmatter({}, TEST_PROJECT_FRONTMATTER)).toEqual(result);
   });
   it('page and project math are combined', async () => {

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -105,6 +105,7 @@ export enum ExportFormats {
   pdftex = 'pdf+tex',
   docx = 'docx',
   xml = 'xml',
+  meca = 'meca',
 }
 
 export type Export = {
@@ -114,6 +115,7 @@ export type Export = {
   article?: string;
   /** sub_articles are only for jats xml export */
   sub_articles?: string[];
+  /** MECA: to, from later */
 } & Record<string, any>;
 
 export type SiteFrontmatter = {
@@ -150,6 +152,8 @@ export type ProjectFrontmatter = SiteFrontmatter & {
   abbreviations?: Record<string, string>;
   exports?: Export[];
   thebe?: boolean | Thebe;
+  requirements?: string[];
+  resources?: string[];
 };
 
 export type PageFrontmatter = Omit<ProjectFrontmatter, 'references'> & {

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -78,7 +78,7 @@ export const PAGE_FRONTMATTER_KEYS = [
 ].concat(PROJECT_FRONTMATTER_KEYS);
 
 // These keys only exist on the project.
-PROJECT_FRONTMATTER_KEYS.push('references');
+PROJECT_FRONTMATTER_KEYS.push('references', 'requirements', 'resources');
 
 export const USE_PROJECT_FALLBACK = [
   'authors',
@@ -617,8 +617,11 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
     output.article = validateString(value.article, incrementOptions('article', opts));
   }
   if (defined(value.sub_articles)) {
-    if (output.format !== ExportFormats.xml) {
-      validationError("sub_articles are only supported for exports of format 'jats'", opts);
+    if (output.format !== ExportFormats.xml && output.format !== ExportFormats.meca) {
+      validationError(
+        "sub_articles are only supported for exports of formats 'jats' or 'meca'",
+        opts,
+      );
     } else {
       output.sub_articles = validateList(
         value.sub_articles,
@@ -811,6 +814,24 @@ export function validateProjectFrontmatterKeys(
       value.thebe,
       incrementOptions('thebe', opts),
       validateThebe,
+    );
+  }
+  if (defined(value.requirements)) {
+    output.requirements = validateList(
+      value.requirements,
+      incrementOptions('requirements', opts),
+      (req, index) => {
+        return validateString(req, incrementOptions(`requirements.${index}`, opts));
+      },
+    );
+  }
+  if (defined(value.resources)) {
+    output.resources = validateList(
+      value.resources,
+      incrementOptions('resources', opts),
+      (res, index) => {
+        return validateString(res, incrementOptions(`resources.${index}`, opts));
+      },
     );
   }
   return output;

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -68,6 +68,8 @@ export const PROJECT_FRONTMATTER_KEYS = [
   'abbreviations',
   'exports',
   'thebe',
+  'requirements',
+  'resources',
 ].concat(SITE_FRONTMATTER_KEYS);
 export const PAGE_FRONTMATTER_KEYS = [
   'kernelspec',
@@ -816,6 +818,8 @@ export function validateProjectFrontmatterKeys(
       validateThebe,
     );
   }
+
+  console.log('REQUIREMENTS', value);
   if (defined(value.requirements)) {
     output.requirements = validateList(
       value.requirements,


### PR DESCRIPTION
This is the frontmatter part of the MECA export. It adds a new export format `meca` as well as `requirements` and `resources` to project frontmatter to list corresponding files to each of those categories.