### PR TITLE
🔗 Improve intersphinx linking

### DIFF
--- a/.changeset/empty-pigs-agree.md
+++ b/.changeset/empty-pigs-agree.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Allow intersphinx to connect without a target


### PR DESCRIPTION
This allows you to also link using `myst:jtex` as a bare link without a target.