### PR TITLE
MECA and MD export

### DIFF
--- a/.changeset/fuzzy-bottles-wink.md
+++ b/.changeset/fuzzy-bottles-wink.md
@@ -1,0 +1,5 @@
+---
+'tex-to-myst': patch
+---
+
+Add comment node functionality

--- a/.changeset/long-sloths-protect.md
+++ b/.changeset/long-sloths-protect.md
@@ -1,0 +1,5 @@
+---
+'myst-cli': patch
+---
+
+Add preliminary MECA export target

--- a/.changeset/many-rockets-arrive.md
+++ b/.changeset/many-rockets-arrive.md
@@ -1,0 +1,5 @@
+---
+'myst-transforms': patch
+---
+
+Track url source when enumerating nodes

--- a/.changeset/slow-buttons-shave.md
+++ b/.changeset/slow-buttons-shave.md
@@ -1,0 +1,5 @@
+---
+'myst-frontmatter': patch
+---
+
+Add frontmatter for requirements and resources.

--- a/.changeset/spotty-candles-whisper.md
+++ b/.changeset/spotty-candles-whisper.md
@@ -1,0 +1,6 @@
+---
+'myst-to-md': patch
+'myst-cli': patch
+---
+
+Incorporate myst-to-md into CLI, making md an export target

--- a/package-lock.json
+++ b/package-lock.json
@@ -12010,7 +12010,8 @@
         "unist-util-select": "^4.0.3",
         "vfile": "^5.3.5",
         "which": "^3.0.1",
-        "ws": "^8.9.0"
+        "ws": "^8.9.0",
+        "xml-js": "^1.6.11"
       },
       "bin": {
         "myst": "dist/myst.cjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11994,6 +11994,7 @@
         "myst-templates": "^1.0.0",
         "myst-to-docx": "^1.0.0",
         "myst-to-jats": "^1.0.1",
+        "myst-to-md": "^1.0.1",
         "myst-to-tex": "^1.0.0",
         "myst-transforms": "^1.0.0",
         "nanoid": "^4.0.0",

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -83,6 +83,7 @@
     "myst-spec-ext": "^1.0.1",
     "myst-templates": "^1.0.0",
     "myst-to-docx": "^1.0.0",
+    "myst-to-md": "^1.0.1",
     "myst-to-jats": "^1.0.1",
     "myst-to-tex": "^1.0.0",
     "myst-transforms": "^1.0.0",

--- a/packages/myst-cli/package.json
+++ b/packages/myst-cli/package.json
@@ -100,7 +100,8 @@
     "unist-util-select": "^4.0.3",
     "vfile": "^5.3.5",
     "which": "^3.0.1",
-    "ws": "^8.9.0"
+    "ws": "^8.9.0",
+    "xml-js": "^1.6.11"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.0",

--- a/packages/myst-cli/src/build/build.spec.ts
+++ b/packages/myst-cli/src/build/build.spec.ts
@@ -31,7 +31,14 @@ describe('getExportFormats', () => {
   });
   it('single build target true in options and all returns all formats', async () => {
     expect(getExportFormats({ all: true, docx: true, pdf: false, tex: false, xml: false })).toEqual(
-      [ExportFormats.docx, ExportFormats.pdf, ExportFormats.tex, ExportFormats.xml],
+      [
+        ExportFormats.docx,
+        ExportFormats.pdf,
+        ExportFormats.tex,
+        ExportFormats.xml,
+        ExportFormats.md,
+        ExportFormats.meca,
+      ],
     );
   });
   it('all build targets true in options returns all formats', async () => {

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -16,6 +16,7 @@ export type BuildOpts = {
   pdf?: boolean;
   tex?: boolean;
   xml?: boolean;
+  meca?: boolean;
   html?: boolean;
   all?: boolean;
   force?: boolean;
@@ -24,12 +25,12 @@ export type BuildOpts = {
 };
 
 export function hasAnyExplicitExportFormat(opts: BuildOpts): boolean {
-  const { docx, pdf, tex, xml } = opts;
-  return docx || pdf || tex || xml || false;
+  const { docx, pdf, tex, xml, meca } = opts;
+  return docx || pdf || tex || xml || meca || false;
 }
 
 export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extension?: string }) {
-  const { docx, pdf, tex, xml, all, explicit, extension } = opts;
+  const { docx, pdf, tex, xml, meca, all, explicit, extension } = opts;
   const formats = [];
   const any = hasAnyExplicitExportFormat(opts);
   const override = all || (!any && explicit && !extension);
@@ -37,13 +38,14 @@ export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extensi
   if (pdf || override || extension === '.pdf') formats.push(ExportFormats.pdf);
   if (tex || override || extension === '.tex') formats.push(ExportFormats.tex);
   if (xml || override || extension === '.xml') formats.push(ExportFormats.xml);
+  if (meca || override) formats.push(ExportFormats.meca);
   return formats;
 }
 
 export function exportSite(session: ISession, opts: BuildOpts) {
-  const { docx, pdf, tex, xml, force, site, html, all } = opts;
+  const { docx, pdf, tex, xml, meca, force, site, html, all } = opts;
   const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
-  return site || html || all || (siteConfig && !force && !docx && !pdf && !tex && !xml);
+  return site || html || all || (siteConfig && !force && !docx && !pdf && !tex && !xml && !meca);
 }
 
 export function getProjectPaths(session: ISession) {

--- a/packages/myst-cli/src/build/build.ts
+++ b/packages/myst-cli/src/build/build.ts
@@ -16,6 +16,7 @@ export type BuildOpts = {
   pdf?: boolean;
   tex?: boolean;
   xml?: boolean;
+  md?: boolean;
   meca?: boolean;
   html?: boolean;
   all?: boolean;
@@ -25,12 +26,12 @@ export type BuildOpts = {
 };
 
 export function hasAnyExplicitExportFormat(opts: BuildOpts): boolean {
-  const { docx, pdf, tex, xml, meca } = opts;
-  return docx || pdf || tex || xml || meca || false;
+  const { docx, pdf, tex, xml, md, meca } = opts;
+  return docx || pdf || tex || xml || md || meca || false;
 }
 
 export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extension?: string }) {
-  const { docx, pdf, tex, xml, meca, all, explicit, extension } = opts;
+  const { docx, pdf, tex, xml, md, meca, all, explicit, extension } = opts;
   const formats = [];
   const any = hasAnyExplicitExportFormat(opts);
   const override = all || (!any && explicit && !extension);
@@ -38,14 +39,17 @@ export function getExportFormats(opts: BuildOpts & { explicit?: boolean; extensi
   if (pdf || override || extension === '.pdf') formats.push(ExportFormats.pdf);
   if (tex || override || extension === '.tex') formats.push(ExportFormats.tex);
   if (xml || override || extension === '.xml') formats.push(ExportFormats.xml);
+  if (md || override || extension === '.md') formats.push(ExportFormats.md);
   if (meca || override) formats.push(ExportFormats.meca);
   return formats;
 }
 
 export function exportSite(session: ISession, opts: BuildOpts) {
-  const { docx, pdf, tex, xml, meca, force, site, html, all } = opts;
+  const { docx, pdf, tex, xml, md, meca, force, site, html, all } = opts;
   const siteConfig = selectors.selectCurrentSiteConfig(session.store.getState());
-  return site || html || all || (siteConfig && !force && !docx && !pdf && !tex && !xml && !meca);
+  return (
+    site || html || all || (siteConfig && !force && !docx && !pdf && !tex && !xml && !md && !meca)
+  );
 }
 
 export function getProjectPaths(session: ISession) {

--- a/packages/myst-cli/src/build/clean.ts
+++ b/packages/myst-cli/src/build/clean.ts
@@ -12,6 +12,7 @@ export type CleanOptions = {
   pdf?: boolean;
   tex?: boolean;
   xml?: boolean;
+  meca?: boolean;
   site?: boolean;
   html?: boolean;
   temp?: boolean;
@@ -26,6 +27,7 @@ const ALL_OPTS: CleanOptions = {
   pdf: true,
   tex: true,
   xml: true,
+  meca: true,
   site: true,
   html: true,
   temp: true,
@@ -37,6 +39,7 @@ const DEFAULT_OPTS: CleanOptions = {
   pdf: true,
   tex: true,
   xml: true,
+  meca: true,
   site: true,
   html: true,
   temp: true,
@@ -44,9 +47,9 @@ const DEFAULT_OPTS: CleanOptions = {
 };
 
 function coerceOpts(opts: CleanOptions) {
-  const { docx, pdf, tex, xml, site, html, temp, exports, templates, all } = opts;
+  const { docx, pdf, tex, xml, meca, site, html, temp, exports, templates, all } = opts;
   if (all) return { ...opts, ...ALL_OPTS };
-  if (!docx && !pdf && !tex && !xml && !site && !html && !temp && !exports && !templates) {
+  if (!docx && !pdf && !tex && !xml && !meca && !site && !html && !temp && !exports && !templates) {
     return { ...opts, ...DEFAULT_OPTS };
   }
   return { ...opts };

--- a/packages/myst-cli/src/build/clean.ts
+++ b/packages/myst-cli/src/build/clean.ts
@@ -12,6 +12,7 @@ export type CleanOptions = {
   pdf?: boolean;
   tex?: boolean;
   xml?: boolean;
+  md?: boolean;
   meca?: boolean;
   site?: boolean;
   html?: boolean;
@@ -27,6 +28,7 @@ const ALL_OPTS: CleanOptions = {
   pdf: true,
   tex: true,
   xml: true,
+  md: true,
   meca: true,
   site: true,
   html: true,
@@ -39,6 +41,7 @@ const DEFAULT_OPTS: CleanOptions = {
   pdf: true,
   tex: true,
   xml: true,
+  md: true,
   meca: true,
   site: true,
   html: true,
@@ -47,9 +50,21 @@ const DEFAULT_OPTS: CleanOptions = {
 };
 
 function coerceOpts(opts: CleanOptions) {
-  const { docx, pdf, tex, xml, meca, site, html, temp, exports, templates, all } = opts;
+  const { docx, pdf, tex, xml, md, meca, site, html, temp, exports, templates, all } = opts;
   if (all) return { ...opts, ...ALL_OPTS };
-  if (!docx && !pdf && !tex && !xml && !meca && !site && !html && !temp && !exports && !templates) {
+  if (
+    !docx &&
+    !pdf &&
+    !tex &&
+    !xml &&
+    !md &&
+    !meca &&
+    !site &&
+    !html &&
+    !temp &&
+    !exports &&
+    !templates
+  ) {
     return { ...opts, ...DEFAULT_OPTS };
   }
   return { ...opts };

--- a/packages/myst-cli/src/build/jats/single.ts
+++ b/packages/myst-cli/src/build/jats/single.ts
@@ -13,7 +13,7 @@ import { KNOWN_IMAGE_EXTENSIONS, logMessagesFromVFile } from '../../utils/index.
 import type { ExportWithOutput, ExportOptions } from '../types.js';
 import {
   cleanOutput,
-  collectJatsExportOptions,
+  collectBasicExportOptions,
   getFileContent,
   resolveAndLogErrors,
 } from '../utils/index.js';
@@ -71,7 +71,7 @@ export async function localArticleToJats(
   if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
-    await collectJatsExportOptions(session, file, 'xml', [ExportFormats.xml], projectPath, opts)
+    await collectBasicExportOptions(session, file, 'xml', [ExportFormats.xml], projectPath, opts)
   ).map((exportOptions) => {
     return { ...exportOptions, ...templateOptions };
   });

--- a/packages/myst-cli/src/build/md/index.ts
+++ b/packages/myst-cli/src/build/md/index.ts
@@ -1,0 +1,71 @@
+import path from 'node:path';
+import { tic, writeFileToFolder } from 'myst-cli-utils';
+import { ExportFormats } from 'myst-frontmatter';
+import { writeMd } from 'myst-to-md';
+import type { LinkTransformer } from 'myst-transforms';
+import { VFile } from 'vfile';
+import { findCurrentProjectAndLoad } from '../../config.js';
+import { loadProjectFromDisk } from '../../project/index.js';
+import type { ISession } from '../../session/types.js';
+import { KNOWN_IMAGE_EXTENSIONS, logMessagesFromVFile } from '../../utils/index.js';
+import type { ExportWithOutput, ExportOptions } from '../types.js';
+import {
+  cleanOutput,
+  collectBasicExportOptions,
+  getFileContent,
+  resolveAndLogErrors,
+} from '../utils/index.js';
+
+export async function runMdExport(
+  session: ISession,
+  exportOptions: ExportWithOutput,
+  projectPath?: string,
+  clean?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+) {
+  const toc = tic();
+  const { output, article } = exportOptions;
+  if (clean) cleanOutput(session, output);
+  const [{ mdast, frontmatter }] = await getFileContent(
+    session,
+    [article],
+    path.join(path.dirname(output), 'files'),
+    {
+      projectPath,
+      imageAltOutputFolder: 'files/',
+      imageExtensions: KNOWN_IMAGE_EXTENSIONS,
+      extraLinkTransformers,
+      simplifyOutputs: false,
+    },
+  );
+  const vfile = new VFile();
+  vfile.path = output;
+  const mdOut = writeMd(vfile, mdast as any, frontmatter);
+  logMessagesFromVFile(session, mdOut);
+  session.log.info(toc(`📑 Exported MD in %s, copying to ${output}`));
+  writeFileToFolder(output, mdOut.result as string);
+}
+
+export async function localArticleToMd(
+  session: ISession,
+  file: string,
+  opts: ExportOptions,
+  templateOptions?: Record<string, any>,
+  extraLinkTransformers?: LinkTransformer[],
+) {
+  let { projectPath } = opts;
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (projectPath) await loadProjectFromDisk(session, projectPath);
+  const exportOptionsList = (
+    await collectBasicExportOptions(session, file, 'md', [ExportFormats.md], projectPath, opts)
+  ).map((exportOptions) => {
+    return { ...exportOptions, ...templateOptions };
+  });
+  await resolveAndLogErrors(
+    session,
+    exportOptionsList.map(async (exportOptions) => {
+      await runMdExport(session, exportOptions, projectPath, opts.clean, extraLinkTransformers);
+    }),
+    opts.throwOnFailure,
+  );
+}

--- a/packages/myst-cli/src/build/md/index.ts
+++ b/packages/myst-cli/src/build/md/index.ts
@@ -32,6 +32,7 @@ export async function runMdExport(
     path.join(path.dirname(output), 'files'),
     {
       projectPath,
+      useExistingImages: true,
       imageAltOutputFolder: 'files/',
       imageExtensions: KNOWN_IMAGE_EXTENSIONS,
       extraLinkTransformers,

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -1,0 +1,142 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { hashAndCopyStaticFile, tic } from 'myst-cli-utils';
+import { ExportFormats } from 'myst-frontmatter';
+import type { LinkTransformer } from 'myst-transforms';
+import { js2xml } from 'xml-js';
+import { findCurrentProjectAndLoad } from '../../config.js';
+import { loadProjectFromDisk } from '../../project/index.js';
+import type { ISession } from '../../session/types.js';
+import { createTempFolder, isDirectory } from '../../utils/index.js';
+import type { ExportWithOutput, ExportOptions } from '../types.js';
+import { cleanOutput, collectJatsExportOptions, resolveAndLogErrors } from '../utils/index.js';
+import { runJatsExport } from '../jats/single.js';
+import AdmZip from 'adm-zip';
+import { selectors } from '../../store/index.js';
+
+function copyFilesFromConfig(
+  session: ISession,
+  projectPath: string,
+  folder: string,
+  category: 'resources' | 'requirements',
+) {
+  const projConfig = selectors.selectLocalProjectConfig(session.store.getState(), projectPath);
+  const entries = projConfig[category];
+  if (entries) {
+    const categoryFolder = path.join(folder, category);
+    const filesToCopy: string[] = [];
+    entries.forEach((entry: string) => {
+      let entryParts = entry.split('/');
+      if (entryParts[entryParts.length] === '*') {
+        entryParts = entryParts.slice(0, entryParts.length - 1);
+      }
+      const resolvedEntry = path.join(projectPath, ...entryParts);
+      if (isDirectory(resolvedEntry)) {
+        fs.readdirSync(resolvedEntry).forEach((file) => {
+          const resolvedSubEntry = path.join(resolvedEntry, file);
+          if (!isDirectory(resolvedSubEntry)) filesToCopy.push(resolvedSubEntry);
+        });
+      } else if (fs.existsSync(resolvedEntry)) {
+        filesToCopy.push(resolvedEntry);
+      }
+    });
+    if (filesToCopy.length) {
+      fs.mkdirSync(categoryFolder);
+      filesToCopy.forEach((file: string) => {
+        hashAndCopyStaticFile(session, file, categoryFolder);
+      });
+    }
+  }
+}
+
+function writeMecaManifest(mecaFolder: string) {
+  const folders = ['files', 'requirements', 'resources'];
+  const files: string[] = [];
+  folders.forEach((folder) => {
+    const fullFolder = path.join(mecaFolder, folder);
+    if (fs.existsSync(fullFolder)) {
+      files.push(...fs.readdirSync(fullFolder).map((file) => `${folder}/${file}`));
+    }
+  });
+  const element = {
+    type: 'element',
+    elements: [
+      {
+        type: 'doctype',
+        doctype: 'manifest SYSTEM "manifest.dtd"',
+      },
+      {
+        type: 'element',
+        name: 'manifest',
+        attributes: { version: '1', xmlns: '' },
+        elements: ['Article.xml', ...files].map((file) => {
+          return {
+            type: 'element',
+            name: 'item',
+            elements: [{ type: 'element', name: 'instance', attributes: { href: file } }],
+          };
+        }),
+      },
+    ],
+    declaration: { attributes: { version: '1.0', encoding: 'UTF-8' } },
+  };
+  const jats = js2xml(element, {
+    compact: false,
+    spaces: 2,
+  });
+  fs.writeFileSync(path.join(mecaFolder, 'Manifest.xml'), jats);
+}
+
+export async function runMecaExport(
+  session: ISession,
+  exportOptions: ExportWithOutput,
+  projectPath?: string,
+  clean?: boolean,
+  extraLinkTransformers?: LinkTransformer[],
+) {
+  const toc = tic();
+  const { output } = exportOptions;
+  if (clean) cleanOutput(session, output);
+  const mecaFolder = createTempFolder(session);
+  const jatsOutput = path.join(mecaFolder, 'Article.xml');
+  await runJatsExport(
+    session,
+    { ...exportOptions, output: jatsOutput },
+    projectPath,
+    clean,
+    extraLinkTransformers,
+  );
+  if (projectPath) {
+    copyFilesFromConfig(session, projectPath, mecaFolder, 'requirements');
+    copyFilesFromConfig(session, projectPath, mecaFolder, 'resources');
+  }
+  writeMecaManifest(mecaFolder);
+  const zip = new AdmZip();
+  zip.addLocalFolder(mecaFolder);
+  zip.writeZip(output);
+  session.log.info(toc(`🤐 MECA output copied and zipped to ${output} in %s`));
+}
+
+export async function localProjectToMeca(
+  session: ISession,
+  file: string,
+  opts: ExportOptions,
+  templateOptions?: Record<string, any>,
+  extraLinkTransformers?: LinkTransformer[],
+) {
+  let { projectPath } = opts;
+  if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
+  if (projectPath) await loadProjectFromDisk(session, projectPath);
+  const exportOptionsList = (
+    await collectJatsExportOptions(session, file, 'zip', [ExportFormats.meca], projectPath, opts)
+  ).map((exportOptions) => {
+    return { ...exportOptions, ...templateOptions };
+  });
+  await resolveAndLogErrors(
+    session,
+    exportOptionsList.map(async (exportOptions) => {
+      await runMecaExport(session, exportOptions, projectPath, opts.clean, extraLinkTransformers);
+    }),
+    opts.throwOnFailure,
+  );
+}

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -9,7 +9,7 @@ import { loadProjectFromDisk } from '../../project/index.js';
 import type { ISession } from '../../session/types.js';
 import { createTempFolder, isDirectory } from '../../utils/index.js';
 import type { ExportWithOutput, ExportOptions } from '../types.js';
-import { cleanOutput, collectJatsExportOptions, resolveAndLogErrors } from '../utils/index.js';
+import { cleanOutput, collectBasicExportOptions, resolveAndLogErrors } from '../utils/index.js';
 import { runJatsExport } from '../jats/single.js';
 import AdmZip from 'adm-zip';
 import { selectors } from '../../store/index.js';
@@ -132,7 +132,7 @@ export async function localProjectToMeca(
   if (!projectPath) projectPath = await findCurrentProjectAndLoad(session, path.dirname(file));
   if (projectPath) await loadProjectFromDisk(session, projectPath);
   const exportOptionsList = (
-    await collectJatsExportOptions(session, file, 'zip', [ExportFormats.meca], projectPath, opts)
+    await collectBasicExportOptions(session, file, 'zip', [ExportFormats.meca], projectPath, opts)
   ).map((exportOptions) => {
     return { ...exportOptions, ...templateOptions };
   });

--- a/packages/myst-cli/src/build/meca/index.ts
+++ b/packages/myst-cli/src/build/meca/index.ts
@@ -63,13 +63,17 @@ function writeMecaManifest(mecaFolder: string) {
     elements: [
       {
         type: 'doctype',
-        doctype: 'manifest SYSTEM "manifest.dtd"',
+        doctype: 'manifest PUBLIC "-//MECA//DTD Manifest v1.0//en" "MECA_manifest.dtd"',
       },
       {
         type: 'element',
         name: 'manifest',
-        attributes: { version: '1', xmlns: '' },
-        elements: ['Article.xml', ...files].map((file) => {
+        attributes: {
+          version: '1',
+          xmlns: 'https://manuscriptexchange.org/schema/manifest',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+        },
+        elements: ['article.xml', ...files].map((file) => {
           return {
             type: 'element',
             name: 'item',
@@ -84,7 +88,7 @@ function writeMecaManifest(mecaFolder: string) {
     compact: false,
     spaces: 2,
   });
-  fs.writeFileSync(path.join(mecaFolder, 'Manifest.xml'), jats);
+  fs.writeFileSync(path.join(mecaFolder, 'manifest.xml'), jats);
 }
 
 export async function runMecaExport(
@@ -98,7 +102,7 @@ export async function runMecaExport(
   const { output } = exportOptions;
   if (clean) cleanOutput(session, output);
   const mecaFolder = createTempFolder(session);
-  const jatsOutput = path.join(mecaFolder, 'Article.xml');
+  const jatsOutput = path.join(mecaFolder, 'article.xml');
   await runJatsExport(
     session,
     { ...exportOptions, output: jatsOutput },

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -304,6 +304,18 @@ export async function collectExportOptions(
           )),
         );
       }
+      if (formats.includes(ExportFormats.meca)) {
+        fileExportOptionsList.push(
+          ...(await collectJatsExportOptions(
+            session,
+            file,
+            'zip',
+            [ExportFormats.meca],
+            fileProjectPath,
+            opts,
+          )),
+        );
+      }
       exportOptionsList.push(
         ...fileExportOptionsList.map((exportOptions) => {
           return { ...exportOptions, $file: file, $project: fileProjectPath };

--- a/packages/myst-cli/src/build/utils/collectExportOptions.ts
+++ b/packages/myst-cli/src/build/utils/collectExportOptions.ts
@@ -174,7 +174,7 @@ export async function collectTexExportOptions(
   return resolvedExportOptions;
 }
 
-export async function collectJatsExportOptions(
+export async function collectBasicExportOptions(
   session: ISession,
   sourceFile: string,
   extension: string,
@@ -294,7 +294,7 @@ export async function collectExportOptions(
       }
       if (formats.includes(ExportFormats.xml)) {
         fileExportOptionsList.push(
-          ...(await collectJatsExportOptions(
+          ...(await collectBasicExportOptions(
             session,
             file,
             'xml',
@@ -304,9 +304,21 @@ export async function collectExportOptions(
           )),
         );
       }
+      if (formats.includes(ExportFormats.md)) {
+        fileExportOptionsList.push(
+          ...(await collectBasicExportOptions(
+            session,
+            file,
+            'md',
+            [ExportFormats.md],
+            fileProjectPath,
+            opts,
+          )),
+        );
+      }
       if (formats.includes(ExportFormats.meca)) {
         fileExportOptionsList.push(
-          ...(await collectJatsExportOptions(
+          ...(await collectBasicExportOptions(
             session,
             file,
             'zip',

--- a/packages/myst-cli/src/build/utils/getFileContent.ts
+++ b/packages/myst-cli/src/build/utils/getFileContent.ts
@@ -22,14 +22,16 @@ export async function getFileContent(
   imageWriteFolder: string,
   {
     projectPath,
+    useExistingImages,
     imageAltOutputFolder,
     imageExtensions,
     extraLinkTransformers,
     simplifyOutputs,
   }: {
-    imageExtensions: ImageExtensions[];
     projectPath?: string;
+    useExistingImages?: boolean;
     imageAltOutputFolder?: string;
+    imageExtensions: ImageExtensions[];
     extraLinkTransformers?: LinkTransformer[];
     simplifyOutputs: boolean;
   },
@@ -63,6 +65,7 @@ export async function getFileContent(
       const pageSlug = pages.find((page) => page.file === file)?.slug;
       await transformMdast(session, {
         file,
+        useExistingImages,
         imageWriteFolder,
         imageAltOutputFolder,
         imageExtensions,

--- a/packages/myst-cli/src/build/utils/localArticleExport.ts
+++ b/packages/myst-cli/src/build/utils/localArticleExport.ts
@@ -10,6 +10,7 @@ import { runWordExport } from '../docx/single.js';
 import { runJatsExport } from '../jats/single.js';
 import { texExportOptionsFromPdf } from '../pdf/single.js';
 import { createPdfGivenTexExport } from '../pdf/create.js';
+import { runMecaExport } from '../meca/index.js';
 
 export async function localArticleExport(
   session: ISession,
@@ -40,6 +41,8 @@ export async function localArticleExport(
         await runWordExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
       } else if (format === ExportFormats.xml) {
         await runJatsExport(sessionClone, exportOptions, fileProjectPath, clean);
+      } else if (format === ExportFormats.meca) {
+        await runMecaExport(sessionClone, exportOptions, fileProjectPath, clean);
       } else {
         const keepTexAndLogs = format === ExportFormats.pdftex;
         const texExportOptions = texExportOptionsFromPdf(

--- a/packages/myst-cli/src/build/utils/localArticleExport.ts
+++ b/packages/myst-cli/src/build/utils/localArticleExport.ts
@@ -11,6 +11,7 @@ import { runJatsExport } from '../jats/single.js';
 import { texExportOptionsFromPdf } from '../pdf/single.js';
 import { createPdfGivenTexExport } from '../pdf/create.js';
 import { runMecaExport } from '../meca/index.js';
+import { runMdExport } from '../md/index.js';
 
 export async function localArticleExport(
   session: ISession,
@@ -41,6 +42,8 @@ export async function localArticleExport(
         await runWordExport(sessionClone, $file, exportOptions, fileProjectPath, clean);
       } else if (format === ExportFormats.xml) {
         await runJatsExport(sessionClone, exportOptions, fileProjectPath, clean);
+      } else if (format === ExportFormats.md) {
+        await runMdExport(sessionClone, exportOptions, fileProjectPath, clean);
       } else if (format === ExportFormats.meca) {
         await runMecaExport(sessionClone, exportOptions, fileProjectPath, clean);
       } else {

--- a/packages/myst-cli/src/cli/build.ts
+++ b/packages/myst-cli/src/cli/build.ts
@@ -15,6 +15,7 @@ import {
   makeNamedExportOption,
   makeHtmlOption,
   makeMecaOptions,
+  makeMdOption,
 } from './options.js';
 
 export function makeBuildCLI(program: Command) {
@@ -24,6 +25,7 @@ export function makeBuildCLI(program: Command) {
     .addOption(makePdfOption('Build PDF output'))
     .addOption(makeTexOption('Build LaTeX outputs'))
     .addOption(makeDocxOption('Build Docx output'))
+    .addOption(makeMdOption('Build MD output'))
     .addOption(makeJatsOption('Build JATS xml output'))
     .addOption(makeMecaOptions('Build MECA zip output'))
     .addOption(makeSiteOption('Build MyST site content'))

--- a/packages/myst-cli/src/cli/build.ts
+++ b/packages/myst-cli/src/cli/build.ts
@@ -14,6 +14,7 @@ import {
   makeAllOption,
   makeNamedExportOption,
   makeHtmlOption,
+  makeMecaOptions,
 } from './options.js';
 
 export function makeBuildCLI(program: Command) {
@@ -24,6 +25,7 @@ export function makeBuildCLI(program: Command) {
     .addOption(makeTexOption('Build LaTeX outputs'))
     .addOption(makeDocxOption('Build Docx output'))
     .addOption(makeJatsOption('Build JATS xml output'))
+    .addOption(makeMecaOptions('Build MECA zip output'))
     .addOption(makeSiteOption('Build MyST site content'))
     .addOption(makeHtmlOption('Build static HTML site content'))
     .addOption(makeAllOption('Build all exports'))

--- a/packages/myst-cli/src/cli/clean.ts
+++ b/packages/myst-cli/src/cli/clean.ts
@@ -7,6 +7,7 @@ import {
   makeDocxOption,
   makeHtmlOption,
   makeJatsOption,
+  makeMecaOptions,
   makePdfOption,
   makeSiteOption,
   makeTexOption,
@@ -41,7 +42,8 @@ export function makeCleanCLI(program: Command) {
     .addOption(makePdfOption('Clean PDF output'))
     .addOption(makeTexOption('Clean LaTeX outputs'))
     .addOption(makeDocxOption('Clean Docx output'))
-    .addOption(makeJatsOption('Build JATS xml output'))
+    .addOption(makeJatsOption('Clean JATS xml output'))
+    .addOption(makeMecaOptions('Clean MECA zip output'))
     .addOption(makeSiteOption('Clean MyST site content'))
     .addOption(makeHtmlOption('Clean static HTML site content'))
     .addOption(makeTempOption())

--- a/packages/myst-cli/src/cli/clean.ts
+++ b/packages/myst-cli/src/cli/clean.ts
@@ -7,6 +7,7 @@ import {
   makeDocxOption,
   makeHtmlOption,
   makeJatsOption,
+  makeMdOption,
   makeMecaOptions,
   makePdfOption,
   makeSiteOption,
@@ -42,6 +43,7 @@ export function makeCleanCLI(program: Command) {
     .addOption(makePdfOption('Clean PDF output'))
     .addOption(makeTexOption('Clean LaTeX outputs'))
     .addOption(makeDocxOption('Clean Docx output'))
+    .addOption(makeMdOption('Clean MD output'))
     .addOption(makeJatsOption('Clean JATS xml output'))
     .addOption(makeMecaOptions('Clean MECA zip output'))
     .addOption(makeSiteOption('Clean MyST site content'))

--- a/packages/myst-cli/src/cli/options.ts
+++ b/packages/myst-cli/src/cli/options.ts
@@ -16,6 +16,10 @@ export function makeJatsOption(description: string) {
   return new Option('--jats, --xml', description).default(false);
 }
 
+export function makeMecaOptions(description: string) {
+  return new Option('--meca', description).default(false);
+}
+
 export function makeSiteOption(description: string) {
   return new Option('--site', description).default(false);
 }

--- a/packages/myst-cli/src/cli/options.ts
+++ b/packages/myst-cli/src/cli/options.ts
@@ -12,6 +12,10 @@ export function makeDocxOption(description: string) {
   return new Option('--word, --docx', description).default(false);
 }
 
+export function makeMdOption(description: string) {
+  return new Option('--md', description).default(false);
+}
+
 export function makeJatsOption(description: string) {
   return new Option('--jats, --xml', description).default(false);
 }

--- a/packages/myst-cli/src/process/mdast.ts
+++ b/packages/myst-cli/src/process/mdast.ts
@@ -88,6 +88,7 @@ export async function transformMdast(
     projectPath?: string;
     projectSlug?: string;
     pageSlug?: string;
+    useExistingImages?: boolean;
     imageAltOutputFolder?: string;
     imageExtensions?: ImageExtensions[];
     watchMode?: boolean;
@@ -102,6 +103,7 @@ export async function transformMdast(
     projectPath,
     pageSlug,
     projectSlug,
+    useExistingImages,
     imageAltOutputFolder,
     imageExtensions,
     extraTransforms,
@@ -180,19 +182,21 @@ export async function transformMdast(
     .use(codePlugin, { lang: frontmatter?.kernelspec?.language })
     .use(footnotesPlugin) // Needs to happen near the end
     .run(mdast, vfile);
-  await transformImages(session, mdast, file, imageWriteFolder, {
-    altOutputFolder: imageAltOutputFolder,
-    imageExtensions,
-  });
-  // Must happen after transformImages
-  await transformImageFormats(session, mdast, file, imageWriteFolder, {
-    altOutputFolder: imageAltOutputFolder,
-    imageExtensions,
-  });
-  // Note, the thumbnail transform must be **after** images, as it may read the images
-  await transformThumbnail(session, mdast, file, frontmatter, imageWriteFolder, {
-    altOutputFolder: imageAltOutputFolder,
-  });
+  if (!useExistingImages) {
+    await transformImages(session, mdast, file, imageWriteFolder, {
+      altOutputFolder: imageAltOutputFolder,
+      imageExtensions,
+    });
+    // Must happen after transformImages
+    await transformImageFormats(session, mdast, file, imageWriteFolder, {
+      altOutputFolder: imageAltOutputFolder,
+      imageExtensions,
+    });
+    // Note, the thumbnail transform must be **after** images, as it may read the images
+    await transformThumbnail(session, mdast, file, frontmatter, imageWriteFolder, {
+      altOutputFolder: imageAltOutputFolder,
+    });
+  }
   const sha256 = selectors.selectFileInfo(store.getState(), file).sha256 as string;
   const useSlug = pageSlug !== index;
   const url = projectSlug

--- a/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
+++ b/packages/myst-frontmatter/src/frontmatter/frontmatter.spec.ts
@@ -147,6 +147,8 @@ const TEST_PROJECT_FRONTMATTER: ProjectFrontmatter = {
       sub_articles: ['my-notebook.ipynb'],
     },
   ],
+  requirements: ['requirements.txt'],
+  resources: ['my-script.sh'],
 };
 const TEST_PAGE_FRONTMATTER: PageFrontmatter = {
   title: 'frontmatter',
@@ -444,6 +446,8 @@ describe('fillPageFrontmatter', () => {
     delete result.name;
     delete result.oxa;
     delete result.exports;
+    delete result.requirements;
+    delete result.resources;
     expect(fillPageFrontmatter({}, TEST_PROJECT_FRONTMATTER)).toEqual(result);
   });
   it('page and project math are combined', async () => {

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -105,6 +105,7 @@ export enum ExportFormats {
   pdftex = 'pdf+tex',
   docx = 'docx',
   xml = 'xml',
+  md = 'md',
   meca = 'meca',
 }
 

--- a/packages/myst-frontmatter/src/frontmatter/types.ts
+++ b/packages/myst-frontmatter/src/frontmatter/types.ts
@@ -105,6 +105,7 @@ export enum ExportFormats {
   pdftex = 'pdf+tex',
   docx = 'docx',
   xml = 'xml',
+  meca = 'meca',
 }
 
 export type Export = {
@@ -114,6 +115,7 @@ export type Export = {
   article?: string;
   /** sub_articles are only for jats xml export */
   sub_articles?: string[];
+  /** MECA: to, from later */
 } & Record<string, any>;
 
 export type SiteFrontmatter = {
@@ -150,6 +152,8 @@ export type ProjectFrontmatter = SiteFrontmatter & {
   abbreviations?: Record<string, string>;
   exports?: Export[];
   thebe?: boolean | Thebe;
+  requirements?: string[];
+  resources?: string[];
 };
 
 export type PageFrontmatter = Omit<ProjectFrontmatter, 'references'> & {

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -78,7 +78,7 @@ export const PAGE_FRONTMATTER_KEYS = [
 ].concat(PROJECT_FRONTMATTER_KEYS);
 
 // These keys only exist on the project.
-PROJECT_FRONTMATTER_KEYS.push('references');
+PROJECT_FRONTMATTER_KEYS.push('references', 'requirements', 'resources');
 
 export const USE_PROJECT_FALLBACK = [
   'authors',
@@ -617,8 +617,11 @@ export function validateExport(input: any, opts: ValidationOptions): Export | un
     output.article = validateString(value.article, incrementOptions('article', opts));
   }
   if (defined(value.sub_articles)) {
-    if (output.format !== ExportFormats.xml) {
-      validationError("sub_articles are only supported for exports of format 'jats'", opts);
+    if (output.format !== ExportFormats.xml && output.format !== ExportFormats.meca) {
+      validationError(
+        "sub_articles are only supported for exports of formats 'jats' or 'meca'",
+        opts,
+      );
     } else {
       output.sub_articles = validateList(
         value.sub_articles,
@@ -811,6 +814,24 @@ export function validateProjectFrontmatterKeys(
       value.thebe,
       incrementOptions('thebe', opts),
       validateThebe,
+    );
+  }
+  if (defined(value.requirements)) {
+    output.requirements = validateList(
+      value.requirements,
+      incrementOptions('requirements', opts),
+      (req, index) => {
+        return validateString(req, incrementOptions(`requirements.${index}`, opts));
+      },
+    );
+  }
+  if (defined(value.resources)) {
+    output.resources = validateList(
+      value.resources,
+      incrementOptions('resources', opts),
+      (res, index) => {
+        return validateString(res, incrementOptions(`resources.${index}`, opts));
+      },
     );
   }
   return output;

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -68,6 +68,8 @@ export const PROJECT_FRONTMATTER_KEYS = [
   'abbreviations',
   'exports',
   'thebe',
+  'requirements',
+  'resources',
 ].concat(SITE_FRONTMATTER_KEYS);
 export const PAGE_FRONTMATTER_KEYS = [
   'kernelspec',
@@ -816,6 +818,8 @@ export function validateProjectFrontmatterKeys(
       validateThebe,
     );
   }
+
+  console.log('REQUIREMENTS', value);
   if (defined(value.requirements)) {
     output.requirements = validateList(
       value.requirements,

--- a/packages/myst-frontmatter/src/frontmatter/validators.ts
+++ b/packages/myst-frontmatter/src/frontmatter/validators.ts
@@ -819,7 +819,6 @@ export function validateProjectFrontmatterKeys(
     );
   }
 
-  console.log('REQUIREMENTS', value);
   if (defined(value.requirements)) {
     output.requirements = validateList(
       value.requirements,

--- a/packages/myst-frontmatter/src/licenses/licenses.spec.ts
+++ b/packages/myst-frontmatter/src/licenses/licenses.spec.ts
@@ -27,12 +27,13 @@ describe('licenses are upto date with SPDX', () => {
         .sort((a, b) => a.licenseId.localeCompare(b.licenseId))
         .map((l) => [
           l.licenseId,
-          {
-            name: l.name,
-            osi: l.isOsiApproved || undefined,
-            free: l.isFsfLibre || undefined,
-            CC: l.licenseId.startsWith('CC') || undefined,
-          },
+          (() => {
+            const out: any = { name: l.name };
+            if (l.isOsiApproved) out.osi = true;
+            if (l.isFsfLibre) out.free = true;
+            if (l.licenseId.startsWith('CC')) out.CC = true;
+            return out;
+          })(),
         ]),
     );
     expect(licenses).toEqual(onlineLicenses);

--- a/packages/myst-to-md/src/index.ts
+++ b/packages/myst-to-md/src/index.ts
@@ -15,35 +15,39 @@ import type { PageFrontmatter } from 'myst-frontmatter';
 const FOOTNOTE_HANDLER_KEYS = ['footnoteDefinition', 'footnoteReference'];
 const TABLE_HANDLER_KEYS = ['table', 'tableRow', 'tableCell'];
 
+export function writeMd(file: VFile, node: Root, frontmatter?: PageFrontmatter) {
+  const handlers = {
+    ...directiveHandlers,
+    ...roleHandlers,
+    ...referenceHandlers,
+    ...miscHandlers,
+  };
+  const handlerKeys = [
+    ...Object.keys(handlers),
+    ...Object.keys(defaultHandlers),
+    ...FOOTNOTE_HANDLER_KEYS,
+    ...TABLE_HANDLER_KEYS,
+  ];
+  const unsupported = unsupportedHandlers(node, handlerKeys, file);
+  const options: Options = {
+    fences: true,
+    rule: '-',
+    handlers: {
+      ...handlers,
+      ...unsupported,
+    },
+    extensions: [gfmFootnoteToMarkdown(), gfmTableToMarkdown()],
+  };
+  const validators = { ...directiveValidators, ...miscValidators };
+  runValidators(node, validators, file);
+  const result = toMarkdown(node as any, options).trim();
+  file.result = addFrontmatter(result, frontmatter);
+  return file;
+}
+
 const plugin: Plugin<[PageFrontmatter?], Root, VFile> = function (frontmatter?) {
   this.Compiler = (node, file) => {
-    const handlers = {
-      ...directiveHandlers,
-      ...roleHandlers,
-      ...referenceHandlers,
-      ...miscHandlers,
-    };
-    const handlerKeys = [
-      ...Object.keys(handlers),
-      ...Object.keys(defaultHandlers),
-      ...FOOTNOTE_HANDLER_KEYS,
-      ...TABLE_HANDLER_KEYS,
-    ];
-    const unsupported = unsupportedHandlers(node, handlerKeys, file);
-    const options: Options = {
-      fences: true,
-      rule: '-',
-      handlers: {
-        ...handlers,
-        ...unsupported,
-      },
-      extensions: [gfmFootnoteToMarkdown(), gfmTableToMarkdown()],
-    };
-    const validators = { ...directiveValidators, ...miscValidators };
-    runValidators(node, validators, file);
-    const result = toMarkdown(node as any, options).trim();
-    file.result = addFrontmatter(result, frontmatter);
-    return file;
+    return writeMd(file, node, frontmatter);
   };
 
   return (node: Root) => {

--- a/packages/myst-to-md/src/misc.ts
+++ b/packages/myst-to-md/src/misc.ts
@@ -3,8 +3,10 @@ import { fileWarn } from 'myst-common';
 import type { VFile } from 'vfile';
 import type { Parent, Validator } from './types.js';
 
-function comment(node: any): string {
-  return `% ${node.value}`;
+function comment(node: any, _: Parent, state: State): string {
+  return state.indentLines(node.value, (line: string, _1: any, blank: boolean) => {
+    return (blank ? '' : '% ') + line;
+  });
 }
 
 function block(node: any, _: Parent, state: State, info: Info): string {

--- a/packages/myst-to-md/src/misc.ts
+++ b/packages/myst-to-md/src/misc.ts
@@ -50,6 +50,7 @@ export const miscHandlers: Record<string, Handle> = {
   definitionList,
   definitionTerm,
   definitionDescription,
+  captionNumber: () => '',
 };
 
 export const miscValidators: Record<string, Validator> = {

--- a/packages/myst-to-md/src/references.ts
+++ b/packages/myst-to-md/src/references.ts
@@ -4,7 +4,7 @@ import type { NestedState, Parent } from './types.js';
 
 function labelWrapper(handler: Handle) {
   return (node: any, _: Parent, state: NestedState, info: Info): string => {
-    const prefix = node.label ? `(${node.label})=\n` : '';
+    const prefix = node.identifier ? `(${node.identifier})=\n` : '';
     return `${prefix}${handler(node, _, state, info)}`;
   };
 }

--- a/packages/myst-to-md/src/references.ts
+++ b/packages/myst-to-md/src/references.ts
@@ -4,7 +4,8 @@ import type { NestedState, Parent } from './types.js';
 
 function labelWrapper(handler: Handle) {
   return (node: any, _: Parent, state: NestedState, info: Info): string => {
-    const prefix = node.identifier ? `(${node.identifier})=\n` : '';
+    const ident = node.identifier ?? node.label;
+    const prefix = ident ? `(${ident})=\n` : '';
     return `${prefix}${handler(node, _, state, info)}`;
   };
 }

--- a/packages/myst-to-md/tests/directives.yml
+++ b/packages/myst-to-md/tests/directives.yml
@@ -210,13 +210,12 @@ cases:
              ```
              ```
     markdown: |-
-      ````{code-block}
+      ````{code-block} python
       :class: my-class
       :emphasize-lines: 2,3
       :name: my-code
       :linenos:
       :lineno-start: 2
-      :lang: python
       :meta: highlight-line="2"
 
       5+5

--- a/packages/myst-to-md/tests/references.yml
+++ b/packages/myst-to-md/tests/references.yml
@@ -6,6 +6,7 @@ cases:
       children:
         - type: paragraph
           label: my-paragraph
+          identifier: my-paragraph
           children:
             - type: text
               value: 'Some % '
@@ -33,6 +34,7 @@ cases:
         - type: heading
           depth: 1
           label: my-heading
+          identifier: my-heading
           children:
             - type: text
               value: first
@@ -83,6 +85,7 @@ cases:
         - type: list
           ordered: false
           label: my-list
+          identifier: my-list
           children:
             - type: listItem
               children:

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -552,6 +552,7 @@ export const resolveReferenceLinksTransform = (tree: Root, opts: StateOptions) =
           source: TRANSFORM_NAME,
         },
       );
+      link.url = `#${link.url}`;
     }
     // Change the link into a cross-reference!
     const xref = link as unknown as CrossReference;

--- a/packages/myst-transforms/src/enumerate.ts
+++ b/packages/myst-transforms/src/enumerate.ts
@@ -552,7 +552,10 @@ export const resolveReferenceLinksTransform = (tree: Root, opts: StateOptions) =
           source: TRANSFORM_NAME,
         },
       );
-      link.url = `#${link.url}`;
+      const source = (link as any).urlSource;
+      if (source) {
+        (link as any).urlSource = `#${source}`;
+      }
     }
     // Change the link into a cross-reference!
     const xref = link as unknown as CrossReference;

--- a/packages/tex-to-myst/src/basic.ts
+++ b/packages/tex-to-myst/src/basic.ts
@@ -1,4 +1,5 @@
 import type { GenericNode } from 'myst-common';
+import { u } from 'unist-builder';
 import type { Handler, ITexParser } from './types.js';
 import { UNHANDLED_ERROR_TEXT, isAccent } from './utils.js';
 
@@ -70,8 +71,12 @@ export const BASIC_TEXT_HANDLERS: Record<string, Handler> = {
     state.stack = [{ type: 'root', children: [] }];
     state.renderChildren(node);
   },
-  comment: () => {
-    // Ignore comments for now
+  comment: (node, state) => {
+    // This prevents in-line comments in paragraphs, which is not valid in myst
+    if (state.top().type === 'paragraph') {
+      state.closeNode();
+    }
+    state.pushNode(u('comment', { position: state.currentPosition }, node.content));
   },
   // Ways to break text...
   macro_newline: closeParagraph,

--- a/packages/tex-to-myst/src/types.ts
+++ b/packages/tex-to-myst/src/types.ts
@@ -32,6 +32,7 @@ export interface ITexParser<D extends Record<string, any> = StateData> {
   data: D;
   options: Options;
   stack: GenericNode[];
+  currentPosition: GenericNode['position'];
   file: VFile;
   text: (value?: string, escape?: boolean) => void;
   renderChildren: (node: any) => void;

--- a/packages/tex-to-myst/tests/figures.yml
+++ b/packages/tex-to-myst/tests/figures.yml
@@ -37,7 +37,7 @@ cases:
       \begin{figure}[ht!]
       \centering
       \includegraphics[width=0.8\linewidth]{img/Figure 4.png}
-      \caption{  \label{fig:4} Solution of the model.
+      \caption{  \label{fig:4}Solution of the model.
       % comment!
       }
       \end{figure}
@@ -58,6 +58,8 @@ cases:
                   children:
                     - type: text
                       value: Solution of the model.
+                - type: comment
+                  value: ' comment!'
   - title: framebox
     tex: |-
       \framebox(400,250){

--- a/packages/tex-to-myst/tests/tables.yml
+++ b/packages/tex-to-myst/tests/tables.yml
@@ -90,6 +90,8 @@ cases:
                     - type: tableCell
                       header: true
                       children:
+                        - type: comment
+                          value: '% tabular useful for creating an array of images'
                         - type: image
                           url: mcr3b.eps
             - type: caption

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -3,7 +3,7 @@
   "display": "Default",
   "compilerOptions": {
     "composite": false,
-    "declaration": false,
+    "declaration": true,
     "declarationMap": true,
     "target": "ES2019",
     "esModuleInterop": true,


### PR DESCRIPTION
This PR includes initial implementation of MECA export - making this PR obsolete: https://github.com/executablebooks/mystjs/pull/423 - as well as implementation of tex -> myst markdown via the CLI. This requires pulling `myst-to-md` into the cli and making some improvements there and in `tex-to-myst`.