### PR TITLE
🐛 Identifiers added to directive child

### DIFF
--- a/.changeset/seven-seas-care.md
+++ b/.changeset/seven-seas-care.md
@@ -1,0 +1,6 @@
+---
+'myst-transforms': patch
+'myst-cli': patch
+---
+
+Propogate identifiers from mystRoles and mystDirectives to their children when lifting

--- a/packages/myst-transforms/src/liftMystDirectivesAndRoles.ts
+++ b/packages/myst-transforms/src/liftMystDirectivesAndRoles.ts
@@ -1,6 +1,8 @@
 import type { Plugin } from 'unified';
 import type { Root } from 'mdast';
+import type { GenericNode } from 'myst-common';
 import { liftChildren } from 'myst-common';
+import { selectAll } from 'unist-util-select';
 
 /**
  * Lift directives and roles and remove them from the tree
@@ -10,6 +12,16 @@ import { liftChildren } from 'myst-common';
  * @param tree The tree which is modified in place.
  */
 export function liftMystDirectivesAndRolesTransform(tree: Root) {
+  const directives = selectAll('mystDirective,mystRole', tree) as GenericNode[];
+  directives.forEach((n) => {
+    const child = n.children?.[0];
+    if (!child) return;
+    if (n.identifier && !child.identifier) {
+      child.identifier = n.identifier;
+      child.label = n.label;
+      child.html_id = n.html_id;
+    }
+  });
   liftChildren(tree, 'mystDirective');
   liftChildren(tree, 'mystRole');
 }


### PR DESCRIPTION
This fixes a bug which was introduced when we changed the order of propogating myst `(targets)=`, which happened before lifting the directives and roles. This now adds the identifiers back onto the first directive/role child.